### PR TITLE
Ensure tests import application package

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -1,8 +1,14 @@
 import contextlib
+import sys
+from pathlib import Path
+
 import pytest
 from hypothesis import settings
 
 from flask import g, request_started
+
+# Ensure the application package on the src/ path is importable
+sys.path.insert(0, str(Path(__file__).resolve().parent / "src"))
 from inventorius import app as inventorius_flask_app
 from inventorius.db import get_mongo_client
 


### PR DESCRIPTION
## Summary
- add src directory to `sys.path` in test configuration so `inventorius` can be imported

## Testing
- `pytest tests/test_data_models.py -q`
- `pytest` *(hangs during state machine tests; abort after ~2 min)*

------
https://chatgpt.com/codex/tasks/task_e_689548236c808331958974509a8e5e6f