### PR TITLE
Add AGENTS instructions for MongoDB and dependencies

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,7 @@
+# AGENTS Instructions
+
+Before working on this repository:
+
+- Install MongoDB (e.g., `sudo apt-get install -y mongodb`) and ensure it is running.
+- Install project dependencies with `pip install -r requirements.txt`.
+


### PR DESCRIPTION
## Summary
- Add AGENTS.md with guidance to install MongoDB and Python dependencies before working in the repo

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'inventorius')*

------
https://chatgpt.com/codex/tasks/task_e_68954bb22da48331b092beb776f3d98e