### PR TITLE
Limit test integers to 64-bit range

### DIFF
--- a/tests/data_models_strategies.py
+++ b/tests/data_models_strategies.py
@@ -19,9 +19,13 @@ import base64
 ids = text(ascii_letters + digits, min_size=1)
 
 fieldNames = text(ascii_lowercase + '_', min_size=1)
-simpleTypes = one_of(none(),
-                     integers(min_value=-2**63, max_value=2**63),
-                     floats(allow_nan=False), text(printable))
+# Constrain integers to the 64-bit signed range supported by MongoDB
+simpleTypes = one_of(
+    none(),
+    integers(min_value=-2**63, max_value=2**63 - 1),
+    floats(allow_nan=False),
+    text(printable),
+)
 
 json = recursive(simpleTypes,
                  lambda children: one_of(


### PR DESCRIPTION
## Summary
- Restrict generated integer props to the 64-bit signed range supported by MongoDB

## Testing
- `timeout 200 pytest -q` (fails: assert 400 == 404)


------
https://chatgpt.com/codex/tasks/task_e_689585cce4cc8331a7e9a586b4c9469f