### PR TITLE
Avoid MongoDB connection failures by clearing collections without dropping

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -38,9 +38,10 @@ def client():
 def clientContext():
     inventorius_flask_app.testing = True
     inventorius_flask_app.secret_key = "1234"
-    get_mongo_client().testing.admin.drop()
-    get_mongo_client().testing.batch.drop()
-    get_mongo_client().testing.bin.drop()
-    get_mongo_client().testing.sku.drop()
-    get_mongo_client().testing.user.drop()
+    test_db = get_mongo_client().testing
+    test_db.admin.delete_many({})
+    test_db.batch.delete_many({})
+    test_db.bin.delete_many({})
+    test_db.sku.delete_many({})
+    test_db.user.delete_many({})
     yield inventorius_flask_app.test_client()


### PR DESCRIPTION
## Summary
- prevent MongoDB from hitting file descriptor limits by clearing test collections with `delete_many` instead of dropping them each test

## Testing
- `pytest tests/test_inventorius_hardcoded.py::test_bin -q`
- `pytest -q`
- `pytest tests/test_inventorius_hardcoded.py::test_bin -q`


------
https://chatgpt.com/codex/tasks/task_e_68960e30d0f88331bf43445bf70b94de