### PR TITLE
Integrate authority hardening into main

### DIFF
--- a/.github/workflows/build-push.yml
+++ b/.github/workflows/build-push.yml
@@ -97,7 +97,7 @@ jobs:
           labels: |
             ${{ steps.meta.outputs.labels }}
             org.opencontainers.image.revision=${{ github.sha }}
-            org.computemachines.component.version=0.3.11
+            org.computemachines.component.version=0.4.1
           build-args: |
             BUILD_ID=${{ github.sha }}
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -26,7 +26,7 @@ COPY src /app/src
 # Immutable source provenance is baked into an image; product release and
 # deployment environment remain runtime settings so one image promotes unchanged.
 ARG BUILD_ID=dev
-ARG COMPONENT_VERSION=0.3.11
+ARG COMPONENT_VERSION=0.4.1
 ENV BUILD_ID=${BUILD_ID}
 LABEL org.opencontainers.image.revision=${BUILD_ID} \
       org.opencontainers.image.version=${COMPONENT_VERSION} \

--- a/README.md
+++ b/README.md
@@ -87,15 +87,22 @@ uv run coverage run --source=inventorius -m pytest
 uv run coverage report
 ```
 
-## Docker Deployment
+## Container Release Channels
 
-The API is deployed as a Docker container via GitHub Actions CI/CD:
+Pushes to `development` publish both the moving `development` image and an
+immutable full-revision image. Pushes to `main` publish only the immutable image:
 
 ```bash
 docker pull ghcr.io/computemachines/inventorius-api:sha-<full-40-character-commit>
 ```
 
-See [inventorius-deploy](https://github.com/computemachines/inventorius-deploy) for the full Docker Compose stack.
+The `main` branch is the component promotion source for coordinated workspace
+releases; it does not publish a mutable deployment tag. Staging advances from a
+coordinated release-candidate manifest, and production uses the accepted image
+digest from that manifest. `latest` is not a deployment channel. See
+[inventorius-deploy](https://github.com/computemachines/inventorius-deploy) for
+the full Docker Compose stack and the workspace `RELEASING.md` for promotion and
+acceptance policy.
 
 ## Environment Variables
 

--- a/src/inventorius/__init__.py
+++ b/src/inventorius/__init__.py
@@ -153,7 +153,7 @@ def get_version():
         db_connected = False
 
     return StatusEndpoint(
-        version="0.4.0",
+        version="0.4.1",
         db_connected=db_connected,
         build_id=os.getenv("BUILD_ID", "dev")
     ).get_response()

--- a/src/inventorius/audit_observation.py
+++ b/src/inventorius/audit_observation.py
@@ -117,9 +117,14 @@ def _identity_sort_key(
     )
 
 
-def canonical_audit_fingerprint(command: dict[str, Any]) -> str:
+def canonical_audit_fingerprint(
+    command: dict[str, Any],
+    *,
+    actor: dict[str, str] | None = None,
+) -> str:
     """Hash domain equality, ignoring incidental row/evidence order."""
     canonical = {
+        "actor": actor,
         "location_id": command["location_id"],
         "snapshot_token": command["snapshot_token"],
         "counts": sorted(
@@ -274,9 +279,10 @@ class AuditObservationRepository:
         command: dict[str, Any],
         *,
         idempotency_key: str,
+        actor: dict[str, str] | None = None,
     ) -> AuditObservationResult:
         """Append one reviewed count against the exact current snapshot."""
-        request_fingerprint = canonical_audit_fingerprint(command)
+        request_fingerprint = canonical_audit_fingerprint(command, actor=actor)
 
         def write(session):
             existing = self._existing_request(
@@ -405,6 +411,25 @@ class AuditObservationRepository:
                     command.get("unresolved_evidence", [])
                 ),
             }
+            if actor is not None:
+                document.update({
+                    "fact_id": document["_id"],
+                    "fact_type": "inventory.audit-observation",
+                    "envelope_version": 1,
+                    "fact_schema": {
+                        "name": "inventory.audit-observation",
+                        "version": 1,
+                    },
+                    "actor": actor,
+                    "command": {
+                        "command_id": document["_id"],
+                        "name": "inventory.audit-observation",
+                        "idempotency_key": idempotency_key,
+                        "request_fingerprint": request_fingerprint,
+                    },
+                    "causation": {},
+                    "evidence": [],
+                })
             self.db.audit_observations.insert_one(document, session=session)
             return AuditObservationResult(
                 self._serialize(document),

--- a/src/inventorius/audit_observations.py
+++ b/src/inventorius/audit_observations.py
@@ -12,7 +12,7 @@ from inventorius.audit_observation import (
     AuditSnapshotStale,
 )
 from inventorius.db import db
-from inventorius.auth import require_capability
+from inventorius.auth import current_actor, require_capability
 from inventorius.inventory_repository import (
     AuditReconciliationRejected,
     InsufficientHolding,
@@ -140,6 +140,7 @@ def audit_observations_post():
         stored = AuditObservationRepository(db).record(
             command,
             idempotency_key=idempotency_key,
+            actor=current_actor().durable_ref(),
         )
     except MissingBin as error:
         return problem.missing_bin_response(str(error))
@@ -208,6 +209,7 @@ def audit_observation_reconciliation_post(observation_id):
             observation_id,
             disposition,
             idempotency_key=idempotency_key,
+            actor=current_actor().durable_ref(),
         )
     except MissingAuditObservation:
         return problem.missing_resource_response(

--- a/src/inventorius/auth/__init__.py
+++ b/src/inventorius/auth/__init__.py
@@ -93,6 +93,9 @@ def init_auth(app: Flask):
         "AUTH_LOCAL_LOGIN_ENABLED",
         _truthy(os.getenv("INVENTORIUS_AUTH_LOCAL_LOGIN_ENABLED")),
     )
+    app.config.setdefault("AUTH_SESSION_IDLE_TTL", timedelta(hours=12))
+    app.config.setdefault("AUTH_SESSION_ABSOLUTE_TTL", timedelta(days=30))
+    app.config.setdefault("AUTH_RECENT_AUTH_TTL", timedelta(minutes=5))
     local_login_error = local_login_safety_error(app.config)
     if local_login_error:
         raise RuntimeError(local_login_error)

--- a/src/inventorius/auth/authority.py
+++ b/src/inventorius/auth/authority.py
@@ -6,10 +6,11 @@ import functools
 import hashlib
 import hmac
 from dataclasses import dataclass
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 from typing import Callable, TypeVar
 
 from flask import current_app, g, jsonify, request
+from pymongo import ReturnDocument
 
 from inventorius.db import db
 
@@ -39,6 +40,7 @@ class Actor:
     capabilities: frozenset[str]
     session_digest: str | None = None
     csrf_token: str | None = None
+    recent_auth_at: datetime | None = None
 
     @property
     def is_authenticated(self) -> bool:
@@ -61,6 +63,17 @@ class Actor:
             "actor_type": self.principal.kind,
         }
 
+    def has_recent_authentication(self) -> bool:
+        """Whether this browser session was recently confirmed with a passkey."""
+
+        if not self.recent_auth_at:
+            return False
+        timestamp = self.recent_auth_at
+        # PyMongo returns BSON dates without timezone information by default.
+        if timestamp.tzinfo is None:
+            timestamp = timestamp.replace(tzinfo=timezone.utc)
+        return timestamp + current_app.config["AUTH_RECENT_AUTH_TTL"] > datetime.now(timezone.utc)
+
 
 ANONYMOUS_ACTOR = Actor(principal=None, capabilities=PUBLIC_CAPABILITIES)
 F = TypeVar("F", bound=Callable)
@@ -78,8 +91,21 @@ def _load_actor() -> Actor:
         digest = token_digest(token)
     except (UnicodeEncodeError, AttributeError):
         return ANONYMOUS_ACTOR
-    session = db.auth_sessions.find_one(
-        {"_id": digest, "expires_at": {"$gt": datetime.now(timezone.utc)}}
+    now = datetime.now(timezone.utc)
+    idle_expires_at = now + current_app.config["AUTH_SESSION_IDLE_TTL"]
+    session = db.auth_sessions.find_one_and_update(
+        {
+            "_id": digest,
+            "expires_at": {"$gt": now},
+            "$or": [
+                {"idle_expires_at": {"$gt": now}},
+                # Sessions issued before idle expiry was introduced retain their
+                # existing absolute expiry and are upgraded on first use.
+                {"idle_expires_at": {"$exists": False}},
+            ],
+        },
+        {"$set": {"last_seen_at": now, "idle_expires_at": idle_expires_at}},
+        return_document=ReturnDocument.AFTER,
     )
     if not session:
         return ANONYMOUS_ACTOR
@@ -95,6 +121,7 @@ def _load_actor() -> Actor:
         capabilities=OWNER_CAPABILITIES,
         session_digest=digest,
         csrf_token=session["csrf_token"],
+        recent_auth_at=session.get("recent_auth_at"),
     )
 
 
@@ -142,6 +169,17 @@ def require_csrf(actor: Actor):
             "Supply the CSRF token from the current auth session.",
         )
     return None
+
+
+def require_recent_authentication(actor: Actor):
+    if actor.has_recent_authentication():
+        return None
+    return _problem(
+        401,
+        "recent-authentication-required",
+        "Recent passkey confirmation required",
+        "Confirm your passkey again before changing account security.",
+    )
 
 
 def require_capability(capability: str):

--- a/src/inventorius/auth/routes.py
+++ b/src/inventorius/auth/routes.py
@@ -20,6 +20,7 @@ from inventorius.auth.authority import (
     public_unsafe,
     require_csrf,
     require_exact_origin,
+    require_recent_authentication,
     token_digest,
 )
 from inventorius.auth.local_login import local_login_available
@@ -29,7 +30,6 @@ from inventorius.db import db
 bp = Blueprint("auth", __name__, url_prefix="/api/auth")
 OWNER_ID = "owner"
 CHALLENGE_TTL = timedelta(minutes=5)
-SESSION_TTL = timedelta(days=30)
 RECOVERY_CODE_COUNT = 10
 
 
@@ -70,12 +70,18 @@ def _session_resource(actor=None):
             "csrf_token": actor.csrf_token,
         }
         operations = [
+            _operation("sessions", "GET", "/api/auth/sessions"),
             _operation(
                 "register-passkey-options",
                 "POST",
                 "/api/auth/bootstrap/registration/options",
             ),
             _operation("logout", "POST", "/api/auth/logout"),
+            _operation(
+                "recent-passkey-options",
+                "POST",
+                "/api/auth/passkeys/recent-authentication/options",
+            ),
         ]
     elif owner:
         state = {"status": "anonymous", "principal": None}
@@ -160,14 +166,18 @@ def _issue_session(principal_id: str, authentication_method: str = "passkey"):
     raw_token = secrets.token_urlsafe(32)
     csrf_token = secrets.token_urlsafe(32)
     digest = token_digest(raw_token)
+    now = _now()
     db.auth_sessions.insert_one(
         {
             "_id": digest,
             "principal_id": principal_id,
             "csrf_token": csrf_token,
             "authentication_method": authentication_method,
-            "created_at": _now(),
-            "expires_at": _now() + SESSION_TTL,
+            "created_at": now,
+            "last_seen_at": now,
+            "recent_auth_at": now if authentication_method == "passkey" else None,
+            "idle_expires_at": now + current_app.config["AUTH_SESSION_IDLE_TTL"],
+            "expires_at": now + current_app.config["AUTH_SESSION_ABSOLUTE_TTL"],
         }
     )
     principal = db.auth_principals.find_one({"_id": principal_id})
@@ -182,6 +192,7 @@ def _issue_session(principal_id: str, authentication_method: str = "passkey"):
         capabilities=OWNER_CAPABILITIES,
         session_digest=digest,
         csrf_token=csrf_token,
+        recent_auth_at=now if authentication_method == "passkey" else None,
     )
     response = make_response(jsonify(_session_resource(actor)))
     response.set_cookie(
@@ -224,6 +235,55 @@ def get_session():
     return jsonify(_session_resource())
 
 
+@bp.get("/sessions")
+def get_sessions():
+    """Return owner-visible metadata for active browser sessions only."""
+
+    actor = current_actor()
+    if not actor.is_authenticated:
+        return _problem(401, "authentication-required", "Authentication required", "Sign in to view active sessions.")
+    now = _now()
+    sessions = list(
+        db.auth_sessions.find(
+            {
+                "principal_id": actor.id,
+                "expires_at": {"$gt": now},
+                "$or": [
+                    {"idle_expires_at": {"$gt": now}},
+                    {"idle_expires_at": {"$exists": False}},
+                ],
+            },
+            {"_id": 1, "created_at": 1, "last_seen_at": 1, "idle_expires_at": 1, "expires_at": 1, "authentication_method": 1},
+        ).sort("created_at", -1)
+    )
+    return jsonify(
+        {
+            "kind": "auth-sessions",
+            "Id": "/api/auth/sessions",
+            "state": {
+                "sessions": [
+                    {
+                        "current": session["_id"] == actor.session_digest,
+                        "created_at": session.get("created_at"),
+                        "last_seen_at": session.get("last_seen_at"),
+                        "idle_expires_at": session.get("idle_expires_at"),
+                        "expires_at": session["expires_at"],
+                        "authentication_method": session.get("authentication_method", "passkey"),
+                    }
+                    for session in sessions
+                ]
+            },
+            "operations": [
+                _operation(
+                    "logout-all-sessions",
+                    "POST",
+                    "/api/auth/logout-all-sessions",
+                )
+            ],
+        }
+    )
+
+
 @bp.post("/bootstrap/registration/options")
 @public_unsafe
 def registration_options():
@@ -240,6 +300,9 @@ def registration_options():
     authorization_digest = None
     if actor.is_authenticated:
         rejected = require_csrf(actor)
+        if rejected:
+            return rejected
+        rejected = require_recent_authentication(actor)
         if rejected:
             return rejected
         authorization = "session"
@@ -360,6 +423,9 @@ def registration_verification():
                 "Authenticate again before registering another passkey.",
             )
         rejected = require_csrf(actor)
+        if rejected:
+            return rejected
+        rejected = require_recent_authentication(actor)
         if rejected:
             return rejected
     try:
@@ -517,6 +583,49 @@ def authentication_options():
     )
 
 
+@bp.post("/passkeys/recent-authentication/options")
+@public_unsafe
+def recent_authentication_options():
+    """Start a passkey ceremony that refreshes this session's authority."""
+
+    rejected = require_exact_origin()
+    if rejected:
+        return rejected
+    actor = current_actor()
+    if not actor.is_authenticated:
+        return _problem(401, "authentication-required", "Authentication required", "Sign in before confirming your passkey.")
+    rejected = require_csrf(actor)
+    if rejected:
+        return rejected
+    credentials = list(db.auth_credentials.find({"principal_id": actor.id}))
+    if not credentials:
+        return _problem(409, "auth-unconfigured", "Passkey authentication unavailable", "No owner passkeys are registered.")
+    challenge = secrets.token_bytes(32)
+    ceremony_id = secrets.token_urlsafe(24)
+    db.auth_challenges.insert_one(
+        {
+            "_id": ceremony_id,
+            "purpose": "recent-authentication",
+            "authorization_digest": actor.session_digest,
+            "challenge": challenge,
+            "created_at": _now(),
+            "expires_at": _now() + CHALLENGE_TTL,
+        }
+    )
+    public_key = webauthn_backend.authentication_options(
+        rp_id=current_app.config["AUTH_RP_ID"],
+        challenge=challenge,
+        credential_ids=[_decode_credential_id(item["_id"]) for item in credentials],
+    )
+    return jsonify(
+        _ceremony_resource(
+            ceremony_id,
+            public_key,
+            "/api/auth/passkeys/recent-authentication/verification",
+        )
+    )
+
+
 @bp.post("/local-login")
 @public_unsafe
 def local_login():
@@ -633,6 +742,58 @@ def authentication_verification():
     return _issue_session(OWNER_ID)
 
 
+@bp.post("/passkeys/recent-authentication/verification")
+@public_unsafe
+def recent_authentication_verification():
+    rejected = require_exact_origin()
+    if rejected:
+        return rejected
+    actor = current_actor()
+    if not actor.is_authenticated:
+        return _problem(401, "authentication-required", "Authentication required", "Sign in before confirming your passkey.")
+    rejected = require_csrf(actor)
+    if rejected:
+        return rejected
+    payload = _json_object()
+    credential_payload = payload.get("credential") if payload else None
+    if not isinstance(credential_payload, dict):
+        return _problem(400, "invalid-request", "Invalid request", "Expected ceremony_id and credential.")
+    challenge_doc = _consume_challenge(str(payload.get("ceremony_id", "")), "recent-authentication")
+    if not challenge_doc or challenge_doc.get("authorization_digest") != actor.session_digest:
+        return _problem(400, "invalid-ceremony", "Passkey confirmation rejected", "The ceremony is invalid, expired, or belongs to another session.")
+    try:
+        credential_id = _encode_credential_id(_decode_credential_id(str(credential_payload.get("id", ""))))
+    except ValueError:
+        return _problem(400, "invalid-passkey", "Passkey confirmation rejected", "The credential id is invalid.")
+    stored = db.auth_credentials.find_one({"_id": credential_id, "principal_id": actor.id})
+    if not stored:
+        return _problem(401, "unknown-passkey", "Passkey confirmation rejected", "The credential is not registered.")
+    try:
+        verified = webauthn_backend.verify_authentication(
+            credential=credential_payload,
+            expected_challenge=challenge_doc["challenge"],
+            expected_rp_id=current_app.config["AUTH_RP_ID"],
+            expected_origin=current_app.config["AUTH_ORIGIN"],
+            credential_public_key=stored["public_key"],
+            credential_current_sign_count=stored["sign_count"],
+        )
+    except Exception:
+        current_app.logger.info("Recent WebAuthn authentication verification failed")
+        return _problem(401, "invalid-passkey", "Passkey confirmation rejected", "The authenticator response could not be verified.")
+    if verified.credential_id != _decode_credential_id(credential_id):
+        return _problem(401, "invalid-passkey", "Passkey confirmation rejected", "The verified credential did not match.")
+    now = _now()
+    db.auth_credentials.update_one(
+        {"_id": credential_id},
+        {"$set": {"sign_count": verified.new_sign_count, "last_used_at": now}},
+    )
+    db.auth_sessions.update_one(
+        {"_id": actor.session_digest, "principal_id": actor.id},
+        {"$set": {"recent_auth_at": now}},
+    )
+    return jsonify(_session_resource())
+
+
 @bp.post("/logout")
 @public_unsafe
 def logout():
@@ -646,5 +807,23 @@ def logout():
         if rejected:
             return rejected
         db.auth_sessions.delete_one({"_id": actor.session_digest})
+    response.delete_cookie(SESSION_COOKIE, path="/", samesite="Lax")
+    return response
+
+
+@bp.post("/logout-all-sessions")
+@public_unsafe
+def logout_all_sessions():
+    rejected = require_exact_origin()
+    if rejected:
+        return rejected
+    actor = current_actor()
+    if not actor.is_authenticated:
+        return _problem(401, "authentication-required", "Authentication required", "Sign in before ending sessions.")
+    rejected = require_csrf(actor) or require_recent_authentication(actor)
+    if rejected:
+        return rejected
+    db.auth_sessions.delete_many({"principal_id": actor.id})
+    response = make_response(jsonify(_session_resource(ANONYMOUS_ACTOR)))
     response.delete_cookie(SESSION_COOKIE, path="/", samesite="Lax")
     return response

--- a/src/inventorius/batch.py
+++ b/src/inventorius/batch.py
@@ -2,7 +2,8 @@ from flask import Blueprint, jsonify, request, Response, url_for, after_this_req
 from voluptuous.error import MultipleInvalid
 from inventorius.data_models import Batch, Bin, Sku, DataModelJSONEncoder as Encoder
 from inventorius.db import db
-from inventorius.auth import require_capability
+from inventorius.auth import current_actor, require_capability
+from inventorius.mutation_receipts import record_mutation
 from inventorius.inventory_repository import (
     InventoryRepository,
     LedgerReferencedBatch,
@@ -59,6 +60,7 @@ def batches_post():
             "BAT",
             command,
             idempotency_key=idempotency_key,
+            actor=current_actor().durable_ref(),
         )
     except ResourceIdempotencyConflict:
         return problem.duplicate_resource_response(
@@ -130,27 +132,26 @@ def batch_patch(id):
     new_batch_doc = Batch.from_json({"_id": id, **json}).to_mongodb_doc()
 
     if "props" in json.keys():
-        db.batch.update_one({"_id": id},
-                            {"$set": {"props": new_batch_doc['props']}})
+        db.batch.update_one({"_id": id}, {"$set": {"props": new_batch_doc['props']}})
     if "name" in json.keys():
-        db.batch.update_one({"_id": id},
-                            {"$set": {"name": new_batch_doc['name']}})
+        db.batch.update_one({"_id": id}, {"$set": {"name": new_batch_doc['name']}})
 
     if "sku_id" in json.keys():
         if not json["sku_id"]:
             db.batch.update_one({"_id": id}, {"$unset": {"sku_id": ""}})
         else:
-            db.batch.update_one({"_id": id},
-                                {"$set": {"sku_id": json['sku_id']}})
+            db.batch.update_one({"_id": id}, {"$set": {"sku_id": json['sku_id']}})
 
     if "owned_codes" in json.keys():
-        db.batch.update_one({"_id": id},
-                            {"$set": {"owned_codes": json['owned_codes']}})
+        db.batch.update_one({"_id": id}, {"$set": {"owned_codes": json['owned_codes']}})
     if "associated_codes" in json.keys():
-        db.batch.update_one({"_id": id},
-                            {"$set": {"associated_codes": json['associated_codes']}})
+        db.batch.update_one({"_id": id}, {"$set": {"associated_codes": json['associated_codes']}})
 
     updated_batch = Batch.from_mongodb_doc(db.batch.find_one({"_id": id}))
+    record_mutation(
+        db, kind="catalog.batch.update", target=id,
+        actor=current_actor().durable_ref(),
+    )
     return BatchEndpoint.from_batch(updated_batch).redirect_response(False)
 
 
@@ -182,6 +183,10 @@ def batch_delete(id):
             }],
         })
 
+    record_mutation(
+        db, kind="catalog.batch.delete", target=id,
+        actor=current_actor().durable_ref(),
+    )
     return BatchEndpoint.from_batch(existing).deleted_success_response()
 
 

--- a/src/inventorius/bin.py
+++ b/src/inventorius/bin.py
@@ -7,7 +7,8 @@ from inventorius.bin_repository import (
     BinRepository,
 )
 from inventorius.db import db
-from inventorius.auth import require_capability
+from inventorius.auth import current_actor, require_capability
+from inventorius.mutation_receipts import record_mutation
 from inventorius.holding_queries import contents_for_bin
 from inventorius.inventory_repository import (
     InventoryRepository,
@@ -53,6 +54,7 @@ def bins_post():
         stored = BinRepository(db).create(
             command,
             idempotency_key=idempotency_key,
+            actor=current_actor().durable_ref(),
         )
     except BinIdempotencyConflict:
         return problem.duplicate_resource_response(
@@ -99,8 +101,11 @@ def bin_patch(id):
         problem.missing_bin_response(id)
 
     if "props" in json.keys():
-        db.bin.update_one({"_id": id},
-                          {"$set": {"props": json['props']}})
+        db.bin.update_one({"_id": id}, {"$set": {"props": json['props']}})
+        record_mutation(
+            db, kind="catalog.bin.update", target=id,
+            actor=current_actor().durable_ref(),
+        )
 
     return BinEndpoint.from_bin(existing).updated_success_response()
 
@@ -121,5 +126,9 @@ def bin_delete(id):
         )
 
     if deleted:
+        record_mutation(
+            db, kind="catalog.bin.delete", target=id,
+            actor=current_actor().durable_ref(),
+        )
         return success.bin_deleted_response(id)
     return problem.dangerous_operation_unforced_response("id", "bin must be empty")

--- a/src/inventorius/bin_repository.py
+++ b/src/inventorius/bin_repository.py
@@ -26,11 +26,12 @@ class BinRepository:
     def db(self):
         return self.repository.db
 
-    def create(self, command, *, idempotency_key):
+    def create(self, command, *, idempotency_key, actor=None):
         return self.repository.create(
             self.prefix,
             command,
             idempotency_key=idempotency_key,
+            actor=actor,
         )
 
     def next_available_id(self):

--- a/src/inventorius/files.py
+++ b/src/inventorius/files.py
@@ -14,7 +14,8 @@ import uuid
 import mimetypes
 
 from inventorius.db import db
-from inventorius.auth import require_capability
+from inventorius.auth import current_actor, require_capability
+from inventorius.mutation_receipts import record_mutation
 from inventorius.util import no_cache
 import inventorius.util_error_responses as problem
 
@@ -239,7 +240,7 @@ def files_post():
         "content_type": content_type,
         "size": final_size,
         "uploaded_at": datetime.now(timezone.utc),
-        "uploaded_by": None,  # TODO: get from current_user when auth added
+        "uploaded_by": current_actor().durable_ref(),
         "is_image": is_image,
         "has_thumbnail": has_thumbnail,
         "width": width,
@@ -247,6 +248,9 @@ def files_post():
     }
 
     db.files.insert_one(metadata)
+    record_mutation(
+        db, kind="file.upload", target=file_id, actor=current_actor().durable_ref()
+    )
 
     # Build response
     state = {
@@ -401,6 +405,9 @@ def file_delete(id):
 
     # Delete from MongoDB
     db.files.delete_one({"_id": id})
+    record_mutation(
+        db, kind="file.delete", target=id, actor=current_actor().durable_ref()
+    )
 
     response = Response()
     response.status_code = 200

--- a/src/inventorius/inventory_operations.py
+++ b/src/inventorius/inventory_operations.py
@@ -247,6 +247,7 @@ def inventory_operation_correction_post(original_operation_id):
             original_operation_id,
             intended_state,
             idempotency_key=idempotency_key,
+            actor=current_actor().durable_ref(),
         )
     except MissingInventoryOperation:
         return problem.missing_resource_response(

--- a/src/inventorius/inventory_repository.py
+++ b/src/inventorius/inventory_repository.py
@@ -1059,6 +1059,7 @@ class InventoryRepository:
         intended_state: dict[str, Any],
         *,
         idempotency_key: str,
+        actor: dict[str, str] | None = None,
     ) -> RepositoryResult:
         """Replace one simple intake receipt with an explicit compensating fact.
 
@@ -1068,6 +1069,7 @@ class InventoryRepository:
         derives every signed leg from that receipt plus the intended state.
         """
         fingerprint_command = {
+            "actor": actor,
             "kind": OperationKind.CORRECTION.value,
             "mode": "replace-receipt",
             "corrects_operation_id": original_operation_id,
@@ -1214,6 +1216,8 @@ class InventoryRepository:
                     request_fingerprint,
                     result,
                     now,
+                    actor=actor,
+                    application_command="inventory.correction",
                 ),
                 session=session,
             )
@@ -1250,6 +1254,7 @@ class InventoryRepository:
         disposition: dict[str, Any],
         *,
         idempotency_key: str,
+        actor: dict[str, str] | None = None,
     ) -> RepositoryResult:
         """Apply one complete, current physical count as an explicit variance.
 
@@ -1259,6 +1264,7 @@ class InventoryRepository:
         boundary rather than inventing a physical counterparty.
         """
         fingerprint_command = {
+            "actor": actor,
             "kind": OperationKind.RECONCILIATION.value,
             "mode": "accept-physical-count",
             "observation_id": observation_id,
@@ -1465,6 +1471,8 @@ class InventoryRepository:
                     request_fingerprint,
                     result,
                     now,
+                    actor=actor,
+                    application_command="inventory.reconciliation",
                 ),
                 session=session,
             )

--- a/src/inventorius/mutation_receipts.py
+++ b/src/inventorius/mutation_receipts.py
@@ -1,0 +1,23 @@
+"""Durable actor receipts for legacy mutable resources.
+
+The inventory ledger already has its own fact model.  Catalog, file, and
+schema records predate that model, so their mutation receipts live separately
+without changing the shape consumed by their older serializers.
+"""
+
+from datetime import datetime, timezone
+from uuid import uuid4
+
+
+def record_mutation(database, *, kind: str, target: str, actor: dict[str, str] | None):
+    """Append the authenticated actor for one successful mutable-resource call."""
+
+    database.mutation_receipts.insert_one({
+        "_id": uuid4().hex,
+        "receipt_type": "inventorius.mutable-resource",
+        "envelope_version": 1,
+        "kind": kind,
+        "target": target,
+        "actor": actor,
+        "recorded_at": datetime.now(timezone.utc),
+    })

--- a/src/inventorius/process_definition.py
+++ b/src/inventorius/process_definition.py
@@ -8,7 +8,8 @@ from pymongo.errors import DuplicateKeyError
 from voluptuous.error import MultipleInvalid
 
 from inventorius.db import db
-from inventorius.auth import require_capability
+from inventorius.auth import current_actor, require_capability
+from inventorius.mutation_receipts import record_mutation
 from inventorius.resource_models import ProcessDefinitionEndpoint
 from inventorius.util import (
     IdentifierSpaceExhausted,
@@ -149,11 +150,13 @@ def process_definitions_post():
         "instructions": content.get("instructions", []),
         "revision": 1,
         "created_at": timestamp,
+        "actor": current_actor().durable_ref(),
     }
     document = {
         "_id": process_id,
         "current_revision": 1,
         "created_at": timestamp,
+        "created_by": current_actor().durable_ref(),
         "revisions": [revision],
     }
 
@@ -163,6 +166,10 @@ def process_definitions_post():
         db.process_definition.insert_one(document)
     except DuplicateKeyError:
         return problem.duplicate_resource_response("id")
+    record_mutation(
+        db, kind="process-definition.create", target=process_id,
+        actor=current_actor().durable_ref(),
+    )
 
     return ProcessDefinitionEndpoint.from_state(
         _state(document)
@@ -272,6 +279,7 @@ def process_definition_patch(id):
         **normalized_content,
         "revision": revision_number,
         "created_at": _now(),
+        "actor": current_actor().durable_ref(),
     }
     result = db.process_definition.update_one(
         {"_id": id, "current_revision": document["current_revision"]},
@@ -285,6 +293,10 @@ def process_definition_patch(id):
             "type": "edit-conflict",
             "title": "The process definition changed. Reload it and try again.",
         })
+    record_mutation(
+        db, kind="process-definition.update", target=id,
+        actor=current_actor().durable_ref(),
+    )
 
     refreshed = db.process_definition.find_one({"_id": id})
     return ProcessDefinitionEndpoint.from_state(
@@ -309,4 +321,8 @@ def process_definition_delete(id):
 
     state = _state(document)
     db.process_definition.delete_one({"_id": id})
+    record_mutation(
+        db, kind="process-definition.delete", target=id,
+        actor=current_actor().durable_ref(),
+    )
     return ProcessDefinitionEndpoint.from_state(state).deleted_success_response()

--- a/src/inventorius/release.py
+++ b/src/inventorius/release.py
@@ -6,7 +6,7 @@ from pathlib import Path
 
 
 COMPONENT = "inventorius-api"
-VERSION = "0.3.11"
+VERSION = "0.4.1"
 MANIFEST_COMPONENT = "api"
 
 

--- a/src/inventorius/resource_repository.py
+++ b/src/inventorius/resource_repository.py
@@ -666,6 +666,7 @@ class ResourceRepository:
         self,
         prefix: str,
         state: dict[str, Any],
+        actor: dict[str, str] | None,
         session,
     ) -> None:
         if prefix == "BAT" and state["sku_id"] is not None:
@@ -683,6 +684,7 @@ class ResourceRepository:
         idempotency_key: str,
         request_fingerprint: str,
         state: dict[str, Any],
+        actor: dict[str, str] | None,
         session,
     ) -> None:
         self.db.resource_commands.insert_one(
@@ -691,6 +693,7 @@ class ResourceRepository:
                 "request_fingerprint": request_fingerprint,
                 "kind": command_kind,
                 "result": state,
+                "actor": actor,
                 "created_at": datetime.now(timezone.utc),
             },
             session=session,
@@ -722,10 +725,11 @@ class ResourceRepository:
         command: dict[str, Any],
         *,
         idempotency_key: str,
+        actor: dict[str, str] | None = None,
     ) -> ResourceCreationResult:
         command_kind = RESOURCE_COMMAND_KINDS[prefix]
         canonical_command = self._canonical_command(prefix, command)
-        request_fingerprint = _fingerprint(canonical_command)
+        request_fingerprint = _fingerprint({"actor": actor, "command": canonical_command})
 
         def write(session):
             existing = self._existing_request(
@@ -743,12 +747,13 @@ class ResourceRepository:
                 requested_id=canonical_command["id"],
             )
             state = {**canonical_command, "id": identifier}
-            self._insert_resource(prefix, state, session)
+            self._insert_resource(prefix, state, actor, session)
             self._insert_receipt(
                 command_kind=command_kind,
                 idempotency_key=idempotency_key,
                 request_fingerprint=request_fingerprint,
                 state=state,
+                actor=actor,
                 session=session,
             )
             return ResourceCreationResult(state, replayed=False)

--- a/src/inventorius/schema/routes.py
+++ b/src/inventorius/schema/routes.py
@@ -4,7 +4,8 @@ import click
 from flask import Blueprint, jsonify, request
 
 from ..db import db
-from ..auth import public_unsafe, require_capability
+from ..auth import current_actor, public_unsafe, require_capability
+from ..mutation_receipts import record_mutation
 from .trigger_engine import (
     Schema,
     TriggerEngine,
@@ -35,11 +36,18 @@ def _save_schema(name: str, schema: Schema) -> None:
     doc = schema_to_dict(schema)
     doc["_id"] = name
     db.schema.replace_one({"_id": name}, doc, upsert=True)
+    record_mutation(
+        db, kind="schema.save", target=name, actor=current_actor().durable_ref()
+    )
 
 
 def _delete_schema(name: str) -> bool:
     """Delete a schema from MongoDB."""
     result = db.schema.delete_one({"_id": name})
+    if result.deleted_count:
+        record_mutation(
+            db, kind="schema.delete", target=name, actor=current_actor().durable_ref()
+        )
     return result.deleted_count > 0
 
 
@@ -373,6 +381,12 @@ def seed_schemas():
     force = request.args.get("force", "false").lower() == "true"
     factories = {**DEFAULT_SCHEMA_FACTORIES, **EXAMPLE_SCHEMA_FACTORIES}
     result = install_schemas(db.schema, factories, force=force)
+    record_mutation(
+        db,
+        kind="schema.seed",
+        target="catalog",
+        actor=current_actor().durable_ref(),
+    )
 
     return jsonify({
         "message": "Seeding complete",

--- a/src/inventorius/schema/routes.py
+++ b/src/inventorius/schema/routes.py
@@ -381,6 +381,12 @@ def seed_schemas():
     force = request.args.get("force", "false").lower() == "true"
     factories = {**DEFAULT_SCHEMA_FACTORIES, **EXAMPLE_SCHEMA_FACTORIES}
     result = install_schemas(db.schema, factories, force=force)
+    record_mutation(
+        db,
+        kind="schema.seed",
+        target="catalog",
+        actor=current_actor().durable_ref(),
+    )
 
     return jsonify({
         "message": "Seeding complete",

--- a/src/inventorius/schema/routes.py
+++ b/src/inventorius/schema/routes.py
@@ -4,7 +4,8 @@ import click
 from flask import Blueprint, jsonify, request
 
 from ..db import db
-from ..auth import public_unsafe, require_capability
+from ..auth import current_actor, public_unsafe, require_capability
+from ..mutation_receipts import record_mutation
 from .trigger_engine import (
     Schema,
     TriggerEngine,
@@ -35,11 +36,18 @@ def _save_schema(name: str, schema: Schema) -> None:
     doc = schema_to_dict(schema)
     doc["_id"] = name
     db.schema.replace_one({"_id": name}, doc, upsert=True)
+    record_mutation(
+        db, kind="schema.save", target=name, actor=current_actor().durable_ref()
+    )
 
 
 def _delete_schema(name: str) -> bool:
     """Delete a schema from MongoDB."""
     result = db.schema.delete_one({"_id": name})
+    if result.deleted_count:
+        record_mutation(
+            db, kind="schema.delete", target=name, actor=current_actor().durable_ref()
+        )
     return result.deleted_count > 0
 
 

--- a/src/inventorius/sku.py
+++ b/src/inventorius/sku.py
@@ -3,7 +3,8 @@ from voluptuous.error import MultipleInvalid
 from voluptuous.schema_builder import Required
 from inventorius.data_models import Sku, Bin, Batch, DataModelJSONEncoder as Encoder
 from inventorius.db import db
-from inventorius.auth import require_capability
+from inventorius.auth import current_actor, require_capability
+from inventorius.mutation_receipts import record_mutation
 from inventorius.inventory_repository import (
     InventoryRepository,
     LedgerReferencedSku,
@@ -56,6 +57,7 @@ def skus_post():
             "SKU",
             command,
             idempotency_key=idempotency_key,
+            actor=current_actor().durable_ref(),
         )
     except ResourceIdempotencyConflict:
         return problem.duplicate_resource_response(
@@ -108,19 +110,19 @@ def sku_patch(id):
         return problem.invalid_params_response(problem.missing_resource_param_error("id"))
 
     if "owned_codes" in json:
-        db.sku.update_one({"_id": id},
-                          {"$set": {"owned_codes": json["owned_codes"]}})
+        db.sku.update_one({"_id": id}, {"$set": {"owned_codes": json["owned_codes"]}})
     if "associated_codes" in json:
-        db.sku.update_one({"_id": id},
-                          {"$set": {"associated_codes": json["associated_codes"]}})
+        db.sku.update_one({"_id": id}, {"$set": {"associated_codes": json["associated_codes"]}})
     if "name" in json:
-        db.sku.update_one({"_id": id},
-                          {"$set": {"name": json["name"]}})
+        db.sku.update_one({"_id": id}, {"$set": {"name": json["name"]}})
     if "props" in json:
-        db.sku.update_one({"_id": id},
-                          {"$set": {"props": json["props"]}})
+        db.sku.update_one({"_id": id}, {"$set": {"props": json["props"]}})
 
     updated_sku = Sku.from_mongodb_doc(db.sku.find_one({"_id": id}))
+    record_mutation(
+        db, kind="catalog.sku.update", target=id,
+        actor=current_actor().durable_ref(),
+    )
     return SkuEndpoint.from_sku(updated_sku).updated_success_response()
 
 @ sku.route('/api/sku/<id>', methods=['DELETE'])
@@ -173,6 +175,10 @@ def sku_delete(id):
         return resp
 
     resp.status_code = 204
+    record_mutation(
+        db, kind="catalog.sku.delete", target=id,
+        actor=current_actor().durable_ref(),
+    )
     return resp
 
 

--- a/tests/test_audit_observations.py
+++ b/tests/test_audit_observations.py
@@ -167,6 +167,18 @@ def test_records_expected_and_unexpected_counts_without_mutating_inventory(
     document = audit_observation_database.audit_observations.find_one({})
     assert document["idempotency_key"] == "reviewed-bin-1"
     assert len(document["request_fingerprint"]) == 64
+    assert document["actor"] == {
+        "actor_id": "owner",
+        "actor_type": "owner",
+    }
+    assert document["fact_id"] == document["_id"]
+    assert document["fact_type"] == "inventory.audit-observation"
+    assert document["command"] == {
+        "command_id": document["_id"],
+        "name": "inventory.audit-observation",
+        "idempotency_key": "reviewed-bin-1",
+        "request_fingerprint": document["request_fingerprint"],
+    }
     assert document["counts"][0]["recorded_quantity"].to_decimal() == Decimal(5)
     assert "idempotency_key" not in str(response.json)
     assert "request_fingerprint" not in str(response.json)

--- a/tests/test_audit_reconciliation.py
+++ b/tests/test_audit_reconciliation.py
@@ -191,6 +191,19 @@ def test_reconciliation_applies_exact_differences_and_links_both_receipts(
     assert stored_operation["reconciles_observation_id"] == (
         observation["observation_id"]
     )
+    assert stored_operation["actor"] == {
+        "actor_id": "owner",
+        "actor_type": "owner",
+    }
+    assert stored_operation["command"] == {
+        "command_id": operation_id,
+        "name": "inventory.reconciliation",
+        "idempotency_key": "apply-audit-variance",
+        "request_fingerprint": stored_operation["request_fingerprint"],
+    }
+    assert stored_operation["causation"] == {
+        "caused_by": [observation["observation_id"]],
+    }
     assert len(stored_operation["request_fingerprint"]) == 64
     assert "idempotency_key" not in str(receipt)
     assert "request_fingerprint" not in str(receipt)

--- a/tests/test_audit_snapshot.py
+++ b/tests/test_audit_snapshot.py
@@ -252,7 +252,9 @@ def test_missing_and_invalid_bin_ids_are_rejected(client, audit_database):
     assert invalid.json["type"] == "validation-error"
 
 
-def test_snapshot_request_does_not_mutate_any_collection(client, audit_database):
+def test_snapshot_request_does_not_mutate_any_collection(
+    anonymous_client, audit_database
+):
     audit_database.bin.insert_one({
         "_id": "BIN000001",
         "contents": {"BAT009999": 7},
@@ -270,7 +272,7 @@ def test_snapshot_request_does_not_mutate_any_collection(client, audit_database)
     )
     before = database_state(audit_database)
 
-    response = get_snapshot(client)
+    response = get_snapshot(anonymous_client)
 
     assert response.status_code == 200
     assert database_state(audit_database) == before

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -369,7 +369,120 @@ def test_authentication_is_discoverable_and_issues_new_session(
     assert {
         operation["rel"]
         for operation in authenticated_session.json["operations"]
-    } == {"register-passkey-options", "logout"}
+    } == {"register-passkey-options", "logout", "sessions", "recent-passkey-options"}
+
+
+def test_expired_or_idle_session_is_anonymous(auth_client):
+    database = get_test_database()
+    _insert_owner(database)
+    now = datetime.now(timezone.utc)
+    for raw_token, expires_at, idle_expires_at in (
+        ("absolute-expired", now - timedelta(seconds=1), now + timedelta(hours=1)),
+        ("idle-expired", now + timedelta(hours=1), now - timedelta(seconds=1)),
+    ):
+        database.auth_sessions.insert_one(
+            {
+                "_id": token_digest(raw_token),
+                "principal_id": "owner",
+                "csrf_token": "csrf",
+                "created_at": now - timedelta(hours=1),
+                "last_seen_at": now - timedelta(hours=1),
+                "idle_expires_at": idle_expires_at,
+                "expires_at": expires_at,
+            }
+        )
+        auth_client.set_cookie("inventorius_session", raw_token)
+        response = auth_client.get("/api/auth/session")
+        assert response.json["state"]["status"] == "anonymous"
+
+
+def test_session_inventory_is_private_and_logout_all_requires_recent_passkey(
+    auth_client, monkeypatch
+):
+    database = get_test_database()
+    _, registered = _register_owner(auth_client, monkeypatch)
+    csrf = registered.json["state"]["csrf_token"]
+    now = datetime.now(timezone.utc)
+    database.auth_sessions.insert_one(
+        {
+            "_id": "other-session",
+            "principal_id": "owner",
+            "csrf_token": "other-csrf",
+            "authentication_method": "passkey",
+            "created_at": now,
+            "last_seen_at": now,
+            "idle_expires_at": now + timedelta(hours=1),
+            "expires_at": now + timedelta(days=1),
+            "recent_auth_at": now,
+        }
+    )
+    inventory = auth_client.get("/api/auth/sessions")
+    assert inventory.status_code == 200
+    assert len(inventory.json["state"]["sessions"]) == 2
+    assert any(item["current"] for item in inventory.json["state"]["sessions"])
+
+    current = database.auth_sessions.find_one({"csrf_token": csrf})
+    database.auth_sessions.update_one(
+        {"_id": current["_id"]},
+        {"$set": {"recent_auth_at": now - timedelta(minutes=6)}},
+    )
+    rejected = auth_client.post(
+        "/api/auth/logout-all-sessions",
+        headers={"Origin": ORIGIN, "X-CSRF-Token": csrf},
+    )
+    assert rejected.status_code == 401
+    assert rejected.json["type"] == "recent-authentication-required"
+    assert database.auth_sessions.count_documents({}) == 2
+
+
+def test_recent_passkey_confirmation_refreshes_current_session(auth_client, monkeypatch):
+    database = get_test_database()
+    _, registered = _register_owner(auth_client, monkeypatch)
+    csrf = registered.json["state"]["csrf_token"]
+    current = database.auth_sessions.find_one({"csrf_token": csrf})
+    database.auth_sessions.update_one(
+        {"_id": current["_id"]},
+        {"$set": {"recent_auth_at": _past_recent_authentication()}},
+    )
+    monkeypatch.setattr(
+        webauthn_backend, "authentication_options", lambda **kwargs: {"challenge": "recent"}
+    )
+    options = auth_client.post(
+        "/api/auth/passkeys/recent-authentication/options",
+        headers={"Origin": ORIGIN, "X-CSRF-Token": csrf},
+    )
+    assert options.status_code == 200
+    monkeypatch.setattr(webauthn_backend, "verify_authentication", lambda **kwargs: _authentication_result())
+    verified = auth_client.post(
+        "/api/auth/passkeys/recent-authentication/verification",
+        json={"ceremony_id": options.json["state"]["ceremony_id"], "credential": {"id": "Y3JlZGVudGlhbC1vbmU"}},
+        headers={"Origin": ORIGIN, "X-CSRF-Token": csrf},
+    )
+    assert verified.status_code == 200
+    refreshed = database.auth_sessions.find_one({"_id": current["_id"]})
+    assert refreshed["recent_auth_at"].replace(tzinfo=timezone.utc) > _past_recent_authentication()
+
+
+def test_registering_another_passkey_requires_recent_confirmation(auth_client, monkeypatch):
+    database = get_test_database()
+    _, registered = _register_owner(auth_client, monkeypatch)
+    csrf = registered.json["state"]["csrf_token"]
+    current = database.auth_sessions.find_one({"csrf_token": csrf})
+    database.auth_sessions.update_one(
+        {"_id": current["_id"]},
+        {"$set": {"recent_auth_at": _past_recent_authentication()}},
+    )
+    response = auth_client.post(
+        "/api/auth/bootstrap/registration/options",
+        json={},
+        headers={"Origin": ORIGIN, "X-CSRF-Token": csrf},
+    )
+    assert response.status_code == 401
+    assert response.json["type"] == "recent-authentication-required"
+
+
+def _past_recent_authentication():
+    return datetime.now(timezone.utc) - timedelta(minutes=6)
 
 
 def test_exact_origin_and_logout_csrf_are_enforced(auth_client, monkeypatch):

--- a/tests/test_inventory_corrections.py
+++ b/tests/test_inventory_corrections.py
@@ -148,6 +148,17 @@ def test_correction_replaces_simple_receive_quantity_or_destination(
         "_id": correction_id,
     })
     assert correction["corrects_operation_id"] == original_id
+    assert correction["actor"] == {
+        "actor_id": "owner",
+        "actor_type": "owner",
+    }
+    assert correction["command"] == {
+        "command_id": correction_id,
+        "name": "inventory.correction",
+        "idempotency_key": "correct-original",
+        "request_fingerprint": correction["request_fingerprint"],
+    }
+    assert correction["causation"] == {"corrects": original_id}
     assert correction["result"]["mode"] == "replace-receipt"
     assert correction["result"]["original_state"] == {
         "batch_id": "BAT000001",

--- a/tests/test_mutation_receipts.py
+++ b/tests/test_mutation_receipts.py
@@ -1,0 +1,93 @@
+"""Contract coverage for actor-attributed legacy mutation receipts."""
+
+from io import BytesIO
+import importlib
+
+import pytest
+
+from tests.database import get_test_database
+
+
+ACTOR = {"actor_id": "owner", "actor_type": "owner"}
+files_module = importlib.import_module("inventorius.files")
+
+
+@pytest.fixture(autouse=True)
+def clean_mutation_receipt_database():
+    database = get_test_database()
+    for name in (
+        "admin", "bin", "sku", "batch", "files", "schema",
+        "process_definition", "process_run", "mutation_receipts",
+        "resource_commands", "resource_identifiers", "identifier_counters",
+    ):
+        database[name].delete_many({})
+    yield database
+
+
+def _receipts(database, *kinds):
+    return list(database.mutation_receipts.find({"kind": {"$in": kinds}}))
+
+
+def test_catalog_update_and_delete_receipts_include_actor(client, clean_mutation_receipt_database):
+    created = client.post(
+        "/api/skus", headers={"Idempotency-Key": "receipt-sku"}, json={"name": "Tape"}
+    )
+    sku_id = created.json["state"]["id"]
+    assert client.patch(f"/api/sku/{sku_id}", json={"name": "Wide tape"}).status_code == 200
+    assert client.delete(f"/api/sku/{sku_id}").status_code == 204
+
+    receipts = _receipts(clean_mutation_receipt_database, "catalog.sku.update", "catalog.sku.delete")
+    assert {receipt["kind"] for receipt in receipts} == {"catalog.sku.update", "catalog.sku.delete"}
+    assert all(receipt["target"] == sku_id and receipt["actor"] == ACTOR for receipt in receipts)
+
+
+def test_file_receipts_include_actor(client, clean_mutation_receipt_database, monkeypatch, tmp_path):
+    monkeypatch.setattr(files_module, "UPLOADS_PATH", str(tmp_path))
+    uploaded = client.post(
+        "/api/files",
+        data={"file": (BytesIO(b"%PDF-1.4\nminimal"), "note.pdf")},
+        content_type="multipart/form-data",
+    )
+    assert uploaded.status_code == 201
+    file_id = uploaded.json["state"]["id"]
+    assert client.delete(f"/api/files/{file_id}").status_code == 200
+
+    receipts = _receipts(clean_mutation_receipt_database, "file.upload", "file.delete")
+    assert {receipt["kind"] for receipt in receipts} == {"file.upload", "file.delete"}
+    assert all(receipt["target"] == file_id and receipt["actor"] == ACTOR for receipt in receipts)
+
+
+def test_schema_administration_and_seed_receipts_include_actor(client, clean_mutation_receipt_database):
+    schema = {"root_mixins": [], "mixins": {}, "intersections": []}
+    assert client.put("/api/schema/test", json=schema).status_code == 200
+    assert client.delete("/api/schema/test").status_code == 200
+    assert client.post("/api/schema/seed").status_code == 200
+
+    receipts = _receipts(clean_mutation_receipt_database, "schema.save", "schema.delete", "schema.seed")
+    assert {receipt["kind"] for receipt in receipts} == {"schema.save", "schema.delete", "schema.seed"}
+    assert all(receipt["actor"] == ACTOR for receipt in receipts)
+
+
+def test_process_mutation_receipts_include_actor(client, clean_mutation_receipt_database):
+    clean_mutation_receipt_database.sku.insert_one({
+        "_id": "SKU000001", "name": "Glue", "owned_codes": [],
+        "associated_codes": [], "props": {},
+    })
+    payload = {
+        "name": "Repack", "kind": "repackaging", "description": "",
+        "inputs": [{"role": "in", "sku_id": "SKU000001", "quantity": 1, "unit": "each"}],
+        "outputs": [{"role": "out", "sku_id": "SKU000001", "quantity": 1, "unit": "each"}],
+        "instructions": [],
+    }
+    assert client.post("/api/process-definitions", json=payload).status_code == 201
+    assert client.patch("/api/process-definition/PRC000001", json={"name": "Repack v2"}).status_code == 200
+    assert client.delete("/api/process-definition/PRC000001").status_code == 200
+
+    receipts = _receipts(
+        clean_mutation_receipt_database,
+        "process-definition.create", "process-definition.update", "process-definition.delete",
+    )
+    assert {receipt["kind"] for receipt in receipts} == {
+        "process-definition.create", "process-definition.update", "process-definition.delete",
+    }
+    assert all(receipt["target"] == "PRC000001" and receipt["actor"] == ACTOR for receipt in receipts)

--- a/tests/test_process_definition.py
+++ b/tests/test_process_definition.py
@@ -79,6 +79,13 @@ def test_create_list_and_get_process_definition(client, clean_process_database):
     assert summary["name"] == "Open glue-stick case"
     assert summary["revision"] == 1
     assert summary["is_current"] is True
+    stored = clean_process_database.process_definition.find_one({
+        "_id": "PRC000001",
+    })
+    assert stored["created_by"] == {"actor_id": "owner", "actor_type": "owner"}
+    assert stored["revisions"][0]["actor"] == {
+        "actor_id": "owner", "actor_type": "owner",
+    }
 
     fetched = client.get("/api/process-definition/PRC1")
     assert fetched.status_code == 200
@@ -117,6 +124,12 @@ def test_patch_appends_revision_and_preserves_old_definition(
     assert current["name"] == "Open case into boxes"
     assert current["outputs"][0]["sku_id"] == "SKU000001"
     assert current["outputs"][0]["quantity"] == 12
+    stored = clean_process_database.process_definition.find_one({
+        "_id": "PRC000001",
+    })
+    assert stored["revisions"][-1]["actor"] == {
+        "actor_id": "owner", "actor_type": "owner",
+    }
 
     original = client.get(
         "/api/process-definition/PRC000001",

--- a/tests/test_release.py
+++ b/tests/test_release.py
@@ -23,7 +23,7 @@ def test_release_metadata_accepts_matching_manifest(tmp_path, monkeypatch):
 
     assert metadata() == {
         "component": "inventorius-api",
-        "component_version": "0.3.11",
+        "component_version": "0.4.1",
         "revision": "a" * 40,
         "product_release": "v0.5.0-rc.1",
         "environment": "development",
@@ -110,7 +110,7 @@ def test_sentry_scrubber_removes_request_and_user_material():
 def test_status_endpoint_preserves_release_provenance():
     with app.test_request_context():
         response = StatusEndpoint(
-            version="0.3.11",
+            version="0.4.1",
             db_connected=True,
             build_id="a" * 40,
             component="inventorius-api",
@@ -120,7 +120,7 @@ def test_status_endpoint_preserves_release_provenance():
         ).get_response()
 
     assert response.get_json()["state"] == {
-        "version": "0.3.11",
+        "version": "0.4.1",
         "is-up": True,
         "db-connected": True,
         "build-id": "a" * 40,

--- a/tests/test_resource_creation.py
+++ b/tests/test_resource_creation.py
@@ -128,6 +128,9 @@ def test_sku_server_allocation_replays_and_persists_returned_state(
         "props": {},
     }
     assert clean_resource_database.resource_commands.count_documents({}) == 1
+    assert clean_resource_database.resource_commands.find_one({})["actor"] == {
+        "actor_id": "owner", "actor_type": "owner",
+    }
     assert clean_resource_database.resource_identifiers.count_documents({
         "_id": "SKU000001",
     }) == 1


### PR DESCRIPTION
Reconciles the development authority/session work with the release-provenance history on main.\n\nVerification:\n- 291 transactional tests pass\n- focused auth, mutation-receipt, and release tests: 34 pass\n- both main d1fe488 and development 5dd5013 are merge parents\n- runtime and OCI component metadata agree on API 0.4.1\n\nThe merge retains caller-aware mutation receipts, session revocation and recent-passkey controls, transactional CI, manifest-backed release identity, and immutable release channels.