### PR TITLE
Advertise typed Batch operations

### DIFF
--- a/src/inventorius/__init__.py
+++ b/src/inventorius/__init__.py
@@ -17,6 +17,7 @@ from flask import Flask, jsonify
 
 from inventorius.bin import bin
 from inventorius.batch import batch
+import inventorius.resource_operations as resource_operation
 from inventorius.inventorius import inventorius
 from inventorius.sku import sku
 from inventorius.files import files
@@ -129,7 +130,7 @@ def api_root():
         command_operations.extend([
             {"rel": "create-bin", "method": "POST", "href": "/api/bins"},
             {"rel": "create-sku", "method": "POST", "href": "/api/skus"},
-            {"rel": "create-batch", "method": "POST", "href": "/api/batches"},
+            resource_operation.batch_create(rel="create-batch"),
             {
                 "rel": "define-process",
                 "method": "POST",

--- a/src/inventorius/batch.py
+++ b/src/inventorius/batch.py
@@ -96,6 +96,10 @@ def batch_get(id):
     existing = Batch.from_mongodb_doc(db.batch.find_one({"_id": id}))
 
     if not existing:
+        if not current_actor().can("catalog.mutate"):
+            return problem.missing_resource_response(
+                url_for("batch.batch_get", id=id)
+            )
         return problem.missing_batch_response(id)
     else:
         return BatchEndpoint.from_batch(existing).get_response()
@@ -152,7 +156,7 @@ def batch_patch(id):
         db, kind="catalog.batch.update", target=id,
         actor=current_actor().durable_ref(),
     )
-    return BatchEndpoint.from_batch(updated_batch).redirect_response(False)
+    return BatchEndpoint.from_batch(updated_batch).updated_success_response()
 
 
 @batch.route("/api/batch/<id>", methods=["DELETE"])

--- a/src/inventorius/resource_operations.py
+++ b/src/inventorius/resource_operations.py
@@ -1,7 +1,38 @@
 from flask import url_for
 
 
-def operation(rel, method, href, expects_a=None):
+_UNSET = object()
+
+
+def schema(name, version=1):
+    return {"name": name, "version": version}
+
+
+def required_creation_idempotency():
+    return {
+        "mode": "required",
+        "key": {
+            "in": "header",
+            "name": "Idempotency-Key",
+            "max_length": 200,
+        },
+        "scope": "resource-creation",
+        "replay": "return-committed-result",
+        "mismatch": "conflict",
+    }
+
+
+def operation(
+    rel,
+    method,
+    href,
+    expects_a=None,
+    *,
+    kind=_UNSET,
+    request_schema=_UNSET,
+    response_schema=_UNSET,
+    idempotency=_UNSET,
+):
     ret = {
         "rel": rel,
         "method": method,
@@ -9,6 +40,16 @@ def operation(rel, method, href, expects_a=None):
     }
     if expects_a:
         ret["Expects-a"] = expects_a
+    typed_fields = (kind, request_schema, response_schema, idempotency)
+    if any(field is not _UNSET for field in typed_fields):
+        if not all(field is not _UNSET for field in typed_fields):
+            raise ValueError("typed operation descriptors require every typed field")
+        ret.update({
+            "kind": kind,
+            "request_schema": request_schema,
+            "response_schema": response_schema,
+            "idempotency": idempotency,
+        })
     return ret
 
 
@@ -21,20 +62,54 @@ OPTION = "OPTION"
 HEAD = "HEAD"
 
 
-def batch_create():
-    return operation("create", POST, url_for("batch.batches_post"), "Batch patch")
+def batch_create(rel="create"):
+    return operation(
+        rel,
+        POST,
+        url_for("batch.batches_post"),
+        "Batch patch",
+        kind="catalog.batch.create",
+        request_schema=schema("inventorius.batch-create"),
+        response_schema=schema("inventorius.batch-creation-result"),
+        idempotency=required_creation_idempotency(),
+    )
 
 
 def batch_update(id):
-    return operation("update", PATCH, url_for("batch.batch_patch", id=id), "Batch patch")
+    return operation(
+        "update",
+        PATCH,
+        url_for("batch.batch_patch", id=id),
+        "Batch patch",
+        kind="catalog.batch.update",
+        request_schema=schema("inventorius.batch-patch"),
+        response_schema=schema("inventorius.operation-status"),
+        idempotency={"mode": "not-supported"},
+    )
 
 
 def batch_delete(id):
-    return operation("delete", DELETE, url_for("batch.batch_delete", id=id))
+    return operation(
+        "delete",
+        DELETE,
+        url_for("batch.batch_delete", id=id),
+        kind="catalog.batch.delete",
+        request_schema=None,
+        response_schema=schema("inventorius.operation-status"),
+        idempotency={"mode": "not-supported"},
+    )
 
 
 def batch_bins(id):
-    return operation("bins", GET, url_for("batch.batch_bins_get", id=id))
+    return operation(
+        "bins",
+        GET,
+        url_for("batch.batch_bins_get", id=id),
+        kind="catalog.batch.locations.read",
+        request_schema=None,
+        response_schema=schema("inventorius.batch-locations"),
+        idempotency={"mode": "not-applicable"},
+    )
 
 
 def process_definition_create():

--- a/tests/test_batch_affordances.py
+++ b/tests/test_batch_affordances.py
@@ -1,0 +1,139 @@
+import pytest
+
+from tests.database import get_test_database
+
+
+@pytest.fixture(autouse=True)
+def batch_document():
+    database = get_test_database()
+    database.batch.delete_many({})
+    database.batch.insert_one({
+        "_id": "BAT000001",
+        "name": "Typed affordance test",
+        "owned_codes": [],
+        "associated_codes": [],
+        "props": {},
+    })
+    yield
+    database.batch.delete_many({})
+
+
+def by_rel(response):
+    return {operation["rel"]: operation for operation in response.json["operations"]}
+
+
+def test_anonymous_batch_advertises_only_typed_locations_read(anonymous_client):
+    response = anonymous_client.get("/api/batch/BAT000001")
+
+    assert response.status_code == 200
+    assert by_rel(response) == {
+        "bins": {
+            "rel": "bins",
+            "method": "GET",
+            "href": "/api/batch/BAT000001/bins",
+            "kind": "catalog.batch.locations.read",
+            "request_schema": None,
+            "response_schema": {
+                "name": "inventorius.batch-locations", "version": 1
+            },
+            "idempotency": {"mode": "not-applicable"},
+        }
+    }
+
+
+def test_missing_batch_create_affordance_is_also_caller_truthful(
+    client, anonymous_client
+):
+    anonymous = anonymous_client.get("/api/batch/BAT999999")
+    owner = client.get("/api/batch/BAT999999")
+
+    assert anonymous.status_code == 404
+    assert "operations" not in anonymous.json
+    assert owner.status_code == 404
+    assert by_rel(owner)["create"]["kind"] == "catalog.batch.create"
+
+
+def test_owner_batch_advertises_typed_update_delete_and_locations(client):
+    operations = by_rel(client.get("/api/batch/BAT000001"))
+
+    assert set(operations) == {"update", "delete", "bins"}
+    assert operations["update"] == {
+        "rel": "update",
+        "method": "PATCH",
+        "href": "/api/batch/BAT000001",
+        "Expects-a": "Batch patch",
+        "kind": "catalog.batch.update",
+        "request_schema": {"name": "inventorius.batch-patch", "version": 1},
+        "response_schema": {
+            "name": "inventorius.operation-status", "version": 1
+        },
+        "idempotency": {"mode": "not-supported"},
+    }
+    assert operations["delete"] == {
+        "rel": "delete",
+        "method": "DELETE",
+        "href": "/api/batch/BAT000001",
+        "kind": "catalog.batch.delete",
+        "request_schema": None,
+        "response_schema": {
+            "name": "inventorius.operation-status", "version": 1
+        },
+        "idempotency": {"mode": "not-supported"},
+    }
+    assert operations["bins"]["idempotency"] == {"mode": "not-applicable"}
+
+
+def test_batch_update_response_matches_advertised_operation_status(client):
+    response = client.patch(
+        "/api/batch/BAT000001",
+        json={"id": "BAT000001", "name": "Updated name"},
+    )
+
+    assert response.status_code == 200
+    assert response.json == {
+        "Id": "/api/batch/BAT000001",
+        "status": "batch updated",
+    }
+
+
+def test_application_root_advertises_typed_batch_creation_only_to_owner(
+    client, anonymous_client
+):
+    assert anonymous_client.get("/api/").json["operations"] == []
+
+    operations = by_rel(client.get("/api/"))
+    create = operations["create-batch"]
+    assert create == {
+        "rel": "create-batch",
+        "method": "POST",
+        "href": "/api/batches",
+        "Expects-a": "Batch patch",
+        "kind": "catalog.batch.create",
+        "request_schema": {"name": "inventorius.batch-create", "version": 1},
+        "response_schema": {
+            "name": "inventorius.batch-creation-result", "version": 1
+        },
+        "idempotency": {
+            "mode": "required",
+            "key": {
+                "in": "header",
+                "name": "Idempotency-Key",
+                "max_length": 200,
+            },
+            "scope": "resource-creation",
+            "replay": "return-committed-result",
+            "mismatch": "conflict",
+        },
+    }
+
+
+def test_batch_endpoint_denies_mutation_even_without_advertisement(anonymous_client):
+    patch = anonymous_client.patch("/api/batch/BAT000001", json={"id": "BAT000001"})
+    delete = anonymous_client.delete("/api/batch/BAT000001")
+    create = anonymous_client.post(
+        "/api/batches", headers={"Idempotency-Key": "denied"}, json={}
+    )
+
+    assert patch.status_code == 401
+    assert delete.status_code == 401
+    assert create.status_code == 401

--- a/tests/test_resource_creation.py
+++ b/tests/test_resource_creation.py
@@ -158,11 +158,20 @@ def test_batch_server_allocation_replays_and_validates_sku_transactionally(
         "owned_codes": [],
         "props": {},
     })
+    conflict = post_batch(client, "create-lot", {
+        **payload,
+        "name": "A different receiving lot",
+    })
     missing = post_batch(client, "missing-sku", {"sku_id": "SKU999999"})
 
     assert first.status_code == 201
     assert replay.status_code == 200
     assert replay.json == first.json
+    assert conflict.status_code == 409
+    assert conflict.json["invalid-params"] == [{
+        "name": "Idempotency-Key",
+        "reason": "must not be reused for a different request",
+    }]
     assert first.json["state"] == {
         "id": "BAT000001",
         "sku_id": "SKU000007",


### PR DESCRIPTION
## Summary
- add complete typed command metadata to Batch affordances
- filter missing-resource creation affordances by caller authority
- align update responses with the advertised operation-status contract
- preserve legacy descriptor compatibility while rejecting partial typed descriptors

## Verification
- focused affordance and resource-creation checks
- branch CI provides Mongo-backed integration coverage