### PR TITLE
Publish immutable dynamic schema revisions

### DIFF
--- a/src/inventorius/schema/catalog.py
+++ b/src/inventorius/schema/catalog.py
@@ -16,6 +16,7 @@ from .sample_schemas import (
     get_sku_schema,
 )
 from .trigger_engine import Schema, schema_to_dict
+from .repository import BOOTSTRAP_ACTOR, SchemaEditConflict, SchemaRepository
 
 
 SchemaFactory = Callable[[], Schema]
@@ -42,28 +43,43 @@ def install_schemas(
     factories: Mapping[str, SchemaFactory] = DEFAULT_SCHEMA_FACTORIES,
     *,
     force: bool = False,
+    actor: dict[str, str] | None = BOOTSTRAP_ACTOR,
 ) -> SchemaInstallResult:
-    """Install schemas without replacing administrator changes by default."""
+    """Install missing schemas and publish forced catalog changes.
+
+    A normal bootstrap preserves every existing logical schema.  A forced
+    bootstrap still uses the immutable publication path: changed catalog
+    content becomes a new revision rather than replacing either the head or its
+    history.
+    """
     installed: list[str] = []
     skipped: list[str] = []
+    repository = SchemaRepository(collection.database)
 
     for name, factory in factories.items():
-        document = schema_to_dict(factory())
-        document["_id"] = name
-
-        if force:
-            collection.replace_one({"_id": name}, document, upsert=True)
-            installed.append(name)
+        definition = schema_to_dict(factory())
+        observed = repository.head(name)
+        if observed.exists and not force:
+            skipped.append(name)
             continue
 
-        result = collection.update_one(
-            {"_id": name},
-            {"$setOnInsert": document},
-            upsert=True,
-        )
-        if result.upserted_id is None:
+        try:
+            publication = repository.publish(
+                name,
+                definition,
+                actor=actor,
+                expected=observed,
+            )
+        except SchemaEditConflict:
+            # Bootstrap is intentionally conservative when another writer wins
+            # the compare-and-swap race.  A later explicit invocation can
+            # evaluate the newly current head.
             skipped.append(name)
-        else:
+            continue
+
+        if publication.changed:
             installed.append(name)
+        else:
+            skipped.append(name)
 
     return SchemaInstallResult(installed=installed, skipped=skipped)

--- a/src/inventorius/schema/repository.py
+++ b/src/inventorius/schema/repository.py
@@ -1,0 +1,406 @@
+"""Immutable publication history for dynamic schemas.
+
+The ``schema`` collection remains a small current-head projection so existing
+read paths stay cheap.  Published definitions live in ``schema_revision`` as
+separate immutable documents addressed by logical schema name and revision.
+"""
+
+from __future__ import annotations
+
+from copy import deepcopy
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from typing import Any
+
+from pymongo.errors import DuplicateKeyError
+from pymongo.read_concern import ReadConcern
+from pymongo.write_concern import WriteConcern
+
+
+COMPATIBILITY_UNSPECIFIED = "unspecified"
+BOOTSTRAP_ACTOR = {
+    "actor_id": "schema-bootstrap",
+    "actor_type": "system",
+}
+
+
+class SchemaEditConflict(RuntimeError):
+    """The schema head changed after a caller read it."""
+
+
+@dataclass(frozen=True)
+class SchemaHead:
+    """One observed logical schema head and its compare-and-swap token."""
+
+    name: str
+    definition: dict[str, Any] | None
+    head_revision: int | None
+    active_revision: int | None
+    exists: bool
+    legacy: bool
+    _document: dict[str, Any] | None
+
+    @property
+    def active(self) -> bool:
+        if not self.exists:
+            return False
+        if self.legacy:
+            return True
+        return (
+            self.head_revision is not None
+            and self.active_revision == self.head_revision
+        )
+
+
+@dataclass(frozen=True)
+class SchemaPublication:
+    """Outcome of publishing or reactivating a schema head."""
+
+    changed: bool
+    revision: int | None
+
+
+def _legacy_definition(document: dict[str, Any]) -> dict[str, Any]:
+    return {
+        key: deepcopy(value)
+        for key, value in document.items()
+        if key != "_id"
+    }
+
+
+def _revision_id(name: str, revision: int) -> dict[str, Any]:
+    return {"schema_name": name, "revision": revision}
+
+
+class SchemaRepository:
+    """Read schema projections and publish immutable revisions with CAS."""
+
+    def __init__(self, database: Any):
+        self.db = database
+
+    @staticmethod
+    def _head_from_document(
+        name: str,
+        document: dict[str, Any] | None,
+    ) -> SchemaHead:
+        if document is None:
+            return SchemaHead(
+                name=name,
+                definition=None,
+                head_revision=None,
+                active_revision=None,
+                exists=False,
+                legacy=False,
+                _document=None,
+            )
+
+        if (
+            isinstance(document.get("head_revision"), int)
+            and isinstance(document.get("definition"), dict)
+        ):
+            return SchemaHead(
+                name=name,
+                definition=deepcopy(document["definition"]),
+                head_revision=document["head_revision"],
+                active_revision=document.get("active_revision"),
+                exists=True,
+                legacy=False,
+                _document=deepcopy(document),
+            )
+
+        return SchemaHead(
+            name=name,
+            definition=_legacy_definition(document),
+            head_revision=None,
+            active_revision=None,
+            exists=True,
+            legacy=True,
+            _document=deepcopy(document),
+        )
+
+    def head(self, name: str, *, session: Any = None) -> SchemaHead:
+        document = self.db.schema.find_one({"_id": name}, session=session)
+        return self._head_from_document(name, document)
+
+    def definition(
+        self,
+        name: str,
+        *,
+        revision: int | None = None,
+    ) -> dict[str, Any] | None:
+        """Return the active projection or one exact published revision."""
+
+        if revision is not None:
+            document = self.db.schema_revision.find_one({
+                "_id": _revision_id(name, revision),
+            })
+            if document is None:
+                return None
+            return deepcopy(document["definition"])
+
+        head = self.head(name)
+        if not head.active:
+            return None
+        return deepcopy(head.definition)
+
+    @staticmethod
+    def _same_observation(expected: SchemaHead, observed: SchemaHead) -> bool:
+        if (
+            expected.exists != observed.exists
+            or expected.legacy != observed.legacy
+        ):
+            return False
+        if not expected.exists:
+            return True
+        if expected.legacy:
+            return expected._document == observed._document
+        return (
+            expected.head_revision == observed.head_revision
+            and expected.active_revision == observed.active_revision
+            and expected.definition == observed.definition
+        )
+
+    @staticmethod
+    def _revision_document(
+        *,
+        name: str,
+        revision: int,
+        parent_revision: int | None,
+        definition: dict[str, Any],
+        actor: dict[str, str] | None,
+        published_at: datetime | None,
+    ) -> dict[str, Any]:
+        return {
+            "_id": _revision_id(name, revision),
+            "schema_name": name,
+            "revision": revision,
+            "parent_revision": parent_revision,
+            "definition": deepcopy(definition),
+            "actor": deepcopy(actor),
+            "published_at": published_at,
+            "compatibility": COMPATIBILITY_UNSPECIFIED,
+        }
+
+    @staticmethod
+    def _head_document(
+        name: str,
+        definition: dict[str, Any],
+        revision: int,
+        *,
+        active: bool,
+    ) -> dict[str, Any]:
+        return {
+            "_id": name,
+            "head_revision": revision,
+            "active_revision": revision if active else None,
+            "definition": deepcopy(definition),
+        }
+
+    def _replace_observed_head(
+        self,
+        observed: SchemaHead,
+        replacement: dict[str, Any],
+        *,
+        session: Any,
+    ) -> None:
+        if not observed.exists:
+            self.db.schema.insert_one(replacement, session=session)
+            return
+
+        if observed.legacy:
+            selector = observed._document
+        else:
+            selector = {
+                "_id": observed.name,
+                "head_revision": observed.head_revision,
+                "active_revision": observed.active_revision,
+                "definition": observed.definition,
+            }
+        result = self.db.schema.replace_one(
+            selector,
+            replacement,
+            session=session,
+        )
+        if result.modified_count != 1:
+            raise SchemaEditConflict(observed.name)
+
+    def publish(
+        self,
+        name: str,
+        definition: dict[str, Any],
+        *,
+        actor: dict[str, str] | None,
+        expected: SchemaHead | None = None,
+    ) -> SchemaPublication:
+        """Publish changed content, preserving every prior definition.
+
+        Legacy flat documents remain readable.  Their first changed publication
+        records the exact pre-revision document as revision 1 with unknown
+        publication metadata, then records the new definition as revision 2.
+        """
+
+        proposed = deepcopy(definition)
+
+        def transaction(session):
+            observed = self.head(name, session=session)
+            if expected is not None and not self._same_observation(
+                expected, observed
+            ):
+                raise SchemaEditConflict(name)
+
+            if observed.exists and observed.definition == proposed:
+                if observed.active:
+                    return SchemaPublication(
+                        changed=False,
+                        revision=observed.head_revision,
+                    )
+                # A PUT is the existing activation seam.  Restoring an
+                # unchanged, revisioned definition does not invent a revision.
+                replacement = self._head_document(
+                    name,
+                    proposed,
+                    observed.head_revision,
+                    active=True,
+                )
+                self._replace_observed_head(
+                    observed,
+                    replacement,
+                    session=session,
+                )
+                return SchemaPublication(
+                    changed=True,
+                    revision=observed.head_revision,
+                )
+
+            timestamp = datetime.now(timezone.utc)
+            if not observed.exists:
+                revision = 1
+                self.db.schema_revision.insert_one(
+                    self._revision_document(
+                        name=name,
+                        revision=revision,
+                        parent_revision=None,
+                        definition=proposed,
+                        actor=actor,
+                        published_at=timestamp,
+                    ),
+                    session=session,
+                )
+            elif observed.legacy:
+                baseline_revision = 1
+                self.db.schema_revision.insert_one(
+                    self._revision_document(
+                        name=name,
+                        revision=baseline_revision,
+                        parent_revision=None,
+                        definition=observed.definition,
+                        actor=None,
+                        published_at=None,
+                    ),
+                    session=session,
+                )
+                revision = 2
+                self.db.schema_revision.insert_one(
+                    self._revision_document(
+                        name=name,
+                        revision=revision,
+                        parent_revision=baseline_revision,
+                        definition=proposed,
+                        actor=actor,
+                        published_at=timestamp,
+                    ),
+                    session=session,
+                )
+            else:
+                revision = observed.head_revision + 1
+                self.db.schema_revision.insert_one(
+                    self._revision_document(
+                        name=name,
+                        revision=revision,
+                        parent_revision=observed.head_revision,
+                        definition=proposed,
+                        actor=actor,
+                        published_at=timestamp,
+                    ),
+                    session=session,
+                )
+
+            self._replace_observed_head(
+                observed,
+                self._head_document(name, proposed, revision, active=True),
+                session=session,
+            )
+            return SchemaPublication(changed=True, revision=revision)
+
+        try:
+            with self.db.client.start_session() as session:
+                return session.with_transaction(
+                    transaction,
+                    read_concern=ReadConcern("snapshot"),
+                    write_concern=WriteConcern("majority"),
+                )
+        except DuplicateKeyError as error:
+            raise SchemaEditConflict(name) from error
+
+    def deactivate(
+        self,
+        name: str,
+        *,
+        expected: SchemaHead | None = None,
+    ) -> bool:
+        """Deactivate the head without removing any published definition."""
+
+        def transaction(session):
+            observed = self.head(name, session=session)
+            if expected is not None and not self._same_observation(
+                expected, observed
+            ):
+                raise SchemaEditConflict(name)
+            if not observed.active:
+                return False
+
+            if observed.legacy:
+                revision = 1
+                self.db.schema_revision.insert_one(
+                    self._revision_document(
+                        name=name,
+                        revision=revision,
+                        parent_revision=None,
+                        definition=observed.definition,
+                        actor=None,
+                        published_at=None,
+                    ),
+                    session=session,
+                )
+            else:
+                revision = observed.head_revision
+
+            self._replace_observed_head(
+                observed,
+                self._head_document(
+                    name,
+                    observed.definition,
+                    revision,
+                    active=False,
+                ),
+                session=session,
+            )
+            return True
+
+        try:
+            with self.db.client.start_session() as session:
+                return session.with_transaction(
+                    transaction,
+                    read_concern=ReadConcern("snapshot"),
+                    write_concern=WriteConcern("majority"),
+                )
+        except DuplicateKeyError as error:
+            raise SchemaEditConflict(name) from error
+
+    def active_names(self) -> list[str]:
+        names = []
+        for document in self.db.schema.find({}):
+            head = self._head_from_document(document["_id"], document)
+            if head.active:
+                names.append(head.name)
+        return names

--- a/src/inventorius/schema/routes.py
+++ b/src/inventorius/schema/routes.py
@@ -1,5 +1,7 @@
 """API routes and operator commands for schema management."""
 
+from copy import deepcopy
+
 import click
 from flask import Blueprint, jsonify, request
 
@@ -17,45 +19,90 @@ from .catalog import (
     EXAMPLE_SCHEMA_FACTORIES,
     install_schemas,
 )
+from .repository import (
+    BOOTSTRAP_ACTOR,
+    SchemaEditConflict,
+    SchemaHead,
+    SchemaRepository,
+)
 
 bp = Blueprint("schema", __name__, url_prefix="/api/schema")
 
 
-def _get_schema(name: str) -> Schema | None:
-    """Get a schema by name from MongoDB."""
-    doc = db.schema.find_one({"_id": name})
-    if doc:
-        # Remove MongoDB _id before converting
-        schema_dict = {k: v for k, v in doc.items() if k != "_id"}
-        return schema_from_dict(schema_dict)
+def _repository() -> SchemaRepository:
+    return SchemaRepository(db)
+
+
+def _get_schema(name: str, revision: int | None = None) -> Schema | None:
+    """Get the active schema or one exact historical revision."""
+    definition = _repository().definition(name, revision=revision)
+    if definition is not None:
+        return schema_from_dict(definition)
     return None
 
 
-def _save_schema(name: str, schema: Schema) -> None:
-    """Save a schema to MongoDB."""
-    doc = schema_to_dict(schema)
-    doc["_id"] = name
-    db.schema.replace_one({"_id": name}, doc, upsert=True)
-    record_mutation(
-        db, kind="schema.save", target=name, actor=current_actor().durable_ref()
+def _save_schema(
+    name: str,
+    schema: Schema,
+    *,
+    expected: SchemaHead,
+) -> None:
+    """Publish a schema revision if its definition changed."""
+    publication = _repository().publish(
+        name,
+        schema_to_dict(schema),
+        actor=current_actor().durable_ref(),
+        expected=expected,
     )
+    if publication.changed:
+        record_mutation(
+            db,
+            kind="schema.save",
+            target=name,
+            actor=current_actor().durable_ref(),
+        )
 
 
-def _delete_schema(name: str) -> bool:
-    """Delete a schema from MongoDB."""
-    result = db.schema.delete_one({"_id": name})
-    if result.deleted_count:
+def _delete_schema(name: str, *, expected: SchemaHead) -> bool:
+    """Deactivate a schema without erasing its publication history."""
+    changed = _repository().deactivate(name, expected=expected)
+    if changed:
         record_mutation(
             db, kind="schema.delete", target=name, actor=current_actor().durable_ref()
         )
-    return result.deleted_count > 0
+    return changed
+
+
+def _requested_revision():
+    revision_text = request.args.get("revision")
+    if revision_text is None:
+        return None, None
+    try:
+        revision = int(revision_text)
+    except ValueError:
+        return None, (jsonify({"error": "revision must be an integer"}), 400)
+    if revision < 1:
+        return None, (jsonify({"error": "revision must be at least 1"}), 400)
+    return revision, None
+
+
+def _schema_for_read(name: str):
+    revision, error_response = _requested_revision()
+    if error_response is not None:
+        return None, error_response
+    return _get_schema(name, revision), None
+
+
+def _edit_conflict_response(name: str):
+    return jsonify({
+        "error": f"Schema '{name}' changed. Reload it and try again."
+    }), 409
 
 
 @bp.route("/list", methods=["GET"])
 def list_schemas():
     """List available schemas from MongoDB."""
-    schema_docs = db.schema.find({}, {"_id": 1})
-    schema_names = [doc["_id"] for doc in schema_docs]
+    schema_names = _repository().active_names()
     return jsonify({
         "schemas": schema_names
     })
@@ -64,7 +111,9 @@ def list_schemas():
 @bp.route("/<name>", methods=["GET"])
 def get_schema(name: str):
     """Get a schema definition by name."""
-    schema = _get_schema(name)
+    schema, error_response = _schema_for_read(name)
+    if error_response is not None:
+        return error_response
     if not schema:
         return jsonify({"error": f"Schema '{name}' not found"}), 404
 
@@ -74,7 +123,9 @@ def get_schema(name: str):
 @bp.route("/<name>/roots", methods=["GET"])
 def get_root_mixins(name: str):
     """Get the root mixins for a schema (available at form start)."""
-    schema = _get_schema(name)
+    schema, error_response = _schema_for_read(name)
+    if error_response is not None:
+        return error_response
     if not schema:
         return jsonify({"error": f"Schema '{name}' not found"}), 404
 
@@ -112,7 +163,9 @@ def evaluate_schema(name: str):
         "available_fields": [...]
     }
     """
-    schema = _get_schema(name)
+    schema, error_response = _schema_for_read(name)
+    if error_response is not None:
+        return error_response
     if not schema:
         return jsonify({"error": f"Schema '{name}' not found"}), 404
 
@@ -155,6 +208,7 @@ def create_or_update_schema(name: str):
 
     Request body: Full schema definition (root_mixins, mixins, intersections)
     """
+    expected = _repository().head(name)
     data = request.get_json()
     if not data:
         return jsonify({"error": "Request body required"}), 400
@@ -164,15 +218,23 @@ def create_or_update_schema(name: str):
     except Exception as e:
         return jsonify({"error": f"Invalid schema: {str(e)}"}), 400
 
-    _save_schema(name, schema)
+    try:
+        _save_schema(name, schema, expected=expected)
+    except SchemaEditConflict:
+        return _edit_conflict_response(name)
     return jsonify({"message": f"Schema '{name}' saved", "schema": schema_to_dict(schema)}), 200
 
 
 @bp.route("/<name>", methods=["DELETE"])
 @require_capability("schema.admin")
 def delete_schema(name: str):
-    """Delete a schema by name."""
-    if _delete_schema(name):
+    """Deactivate a schema while retaining its immutable history."""
+    expected = _repository().head(name)
+    try:
+        changed = _delete_schema(name, expected=expected)
+    except SchemaEditConflict:
+        return _edit_conflict_response(name)
+    if changed:
         return jsonify({"message": f"Schema '{name}' deleted"}), 200
     else:
         return jsonify({"error": f"Schema '{name}' not found"}), 404
@@ -188,9 +250,10 @@ def create_or_update_mixin(name: str, mixin_name: str):
     """
     from .trigger_engine import mixin_from_dict, mixin_to_dict
 
-    schema = _get_schema(name)
-    if not schema:
+    expected = _repository().head(name)
+    if not expected.active:
         return jsonify({"error": f"Schema '{name}' not found"}), 404
+    schema = schema_from_dict(deepcopy(expected.definition))
 
     data = request.get_json()
     if not data:
@@ -205,7 +268,10 @@ def create_or_update_mixin(name: str, mixin_name: str):
         return jsonify({"error": f"Invalid mixin: {str(e)}"}), 400
 
     schema.mixins[mixin_name] = mixin
-    _save_schema(name, schema)
+    try:
+        _save_schema(name, schema, expected=expected)
+    except SchemaEditConflict:
+        return _edit_conflict_response(name)
 
     return jsonify({
         "message": f"Mixin '{mixin_name}' saved in schema '{name}'",
@@ -217,9 +283,10 @@ def create_or_update_mixin(name: str, mixin_name: str):
 @require_capability("schema.admin")
 def delete_mixin(name: str, mixin_name: str):
     """Delete a mixin from a schema."""
-    schema = _get_schema(name)
-    if not schema:
+    expected = _repository().head(name)
+    if not expected.active:
         return jsonify({"error": f"Schema '{name}' not found"}), 404
+    schema = schema_from_dict(deepcopy(expected.definition))
 
     if mixin_name not in schema.mixins:
         return jsonify({"error": f"Mixin '{mixin_name}' not found in schema '{name}'"}), 404
@@ -229,7 +296,10 @@ def delete_mixin(name: str, mixin_name: str):
         schema.root_mixins.remove(mixin_name)
 
     del schema.mixins[mixin_name]
-    _save_schema(name, schema)
+    try:
+        _save_schema(name, schema, expected=expected)
+    except SchemaEditConflict:
+        return _edit_conflict_response(name)
 
     return jsonify({"message": f"Mixin '{mixin_name}' deleted from schema '{name}'"}), 200
 
@@ -238,16 +308,20 @@ def delete_mixin(name: str, mixin_name: str):
 @require_capability("schema.admin")
 def add_root_mixin(name: str, mixin_name: str):
     """Add a mixin to the root_mixins list."""
-    schema = _get_schema(name)
-    if not schema:
+    expected = _repository().head(name)
+    if not expected.active:
         return jsonify({"error": f"Schema '{name}' not found"}), 404
+    schema = schema_from_dict(deepcopy(expected.definition))
 
     if mixin_name not in schema.mixins:
         return jsonify({"error": f"Mixin '{mixin_name}' does not exist in schema"}), 400
 
     if mixin_name not in schema.root_mixins:
         schema.root_mixins.append(mixin_name)
-        _save_schema(name, schema)
+        try:
+            _save_schema(name, schema, expected=expected)
+        except SchemaEditConflict:
+            return _edit_conflict_response(name)
 
     return jsonify({
         "message": f"'{mixin_name}' added to root_mixins",
@@ -259,13 +333,17 @@ def add_root_mixin(name: str, mixin_name: str):
 @require_capability("schema.admin")
 def remove_root_mixin(name: str, mixin_name: str):
     """Remove a mixin from the root_mixins list."""
-    schema = _get_schema(name)
-    if not schema:
+    expected = _repository().head(name)
+    if not expected.active:
         return jsonify({"error": f"Schema '{name}' not found"}), 404
+    schema = schema_from_dict(deepcopy(expected.definition))
 
     if mixin_name in schema.root_mixins:
         schema.root_mixins.remove(mixin_name)
-        _save_schema(name, schema)
+        try:
+            _save_schema(name, schema, expected=expected)
+        except SchemaEditConflict:
+            return _edit_conflict_response(name)
         return jsonify({
             "message": f"'{mixin_name}' removed from root_mixins",
             "root_mixins": schema.root_mixins
@@ -299,7 +377,9 @@ def search_bundles(name: str):
     """
     from .trigger_engine import schema_field_to_dict
 
-    schema = _get_schema(name)
+    schema, error_response = _schema_for_read(name)
+    if error_response is not None:
+        return error_response
     if not schema:
         return jsonify({"error": f"Schema '{name}' not found"}), 404
 
@@ -380,7 +460,12 @@ def seed_schemas():
     """
     force = request.args.get("force", "false").lower() == "true"
     factories = {**DEFAULT_SCHEMA_FACTORIES, **EXAMPLE_SCHEMA_FACTORIES}
-    result = install_schemas(db.schema, factories, force=force)
+    result = install_schemas(
+        db.schema,
+        factories,
+        force=force,
+        actor=current_actor().durable_ref(),
+    )
     record_mutation(
         db,
         kind="schema.seed",
@@ -412,6 +497,11 @@ def bootstrap_schemas(force: bool, include_examples: bool) -> None:
     if include_examples:
         factories.update(EXAMPLE_SCHEMA_FACTORIES)
 
-    result = install_schemas(db.schema, factories, force=force)
+    result = install_schemas(
+        db.schema,
+        factories,
+        force=force,
+        actor=BOOTSTRAP_ACTOR,
+    )
     click.echo(f"Installed: {', '.join(result.installed) or 'none'}")
     click.echo(f"Preserved: {', '.join(result.skipped) or 'none'}")

--- a/tests/test_schema_catalog.py
+++ b/tests/test_schema_catalog.py
@@ -1,37 +1,92 @@
-"""Tests for installing built-in schemas without clobbering edits."""
+"""Tests for publishing built-in schemas without clobbering edits."""
 
-from types import SimpleNamespace
-from unittest.mock import Mock
+import pytest
 
 from inventorius.schema.catalog import DEFAULT_SCHEMA_FACTORIES, install_schemas
+from inventorius.schema.sample_schemas import get_sku_schema
+from tests.database import get_test_database
+
+
+@pytest.fixture(autouse=True)
+def clean_schema_catalog_database():
+    database = get_test_database()
+    database.schema.delete_many({})
+    database.schema_revision.delete_many({})
+    yield database
 
 
 def test_default_catalog_contains_only_application_schemas():
     assert list(DEFAULT_SCHEMA_FACTORIES) == ["sku", "batch"]
 
 
-def test_install_schemas_reports_installed_and_preserved_documents():
-    collection = Mock()
-    collection.update_one.side_effect = [
-        SimpleNamespace(upserted_id="sku"),
-        SimpleNamespace(upserted_id=None),
+def test_install_schemas_reports_installed_and_preserved_documents(
+    clean_schema_catalog_database,
+):
+    collection = clean_schema_catalog_database.schema
+
+    first = install_schemas(collection)
+    second = install_schemas(collection)
+
+    assert first.installed == ["sku", "batch"]
+    assert first.skipped == []
+    assert second.installed == []
+    assert second.skipped == ["sku", "batch"]
+    head = collection.find_one({"_id": "sku"})
+    assert head["head_revision"] == 1
+    assert head["active_revision"] == 1
+    assert head["definition"]["root_mixins"] == ["ItemTypeSelector"]
+
+
+def test_force_install_publishes_changed_content_instead_of_replacing_history(
+    clean_schema_catalog_database,
+):
+    collection = clean_schema_catalog_database.schema
+    assert install_schemas(collection, {"sku": get_sku_schema}).installed == [
+        "sku"
     ]
 
-    result = install_schemas(collection)
+    def changed_sku_schema():
+        schema = get_sku_schema()
+        schema.root_mixins = []
+        return schema
+
+    result = install_schemas(
+        collection,
+        {"sku": changed_sku_schema},
+        force=True,
+    )
 
     assert result.installed == ["sku"]
-    assert result.skipped == ["batch"]
-    first_document = collection.update_one.call_args_list[0].args[1]["$setOnInsert"]
-    assert first_document["_id"] == "sku"
-    assert first_document["root_mixins"] == ["ItemTypeSelector"]
-
-
-def test_force_install_replaces_existing_documents():
-    collection = Mock()
-
-    result = install_schemas(collection, force=True)
-
-    assert result.installed == ["sku", "batch"]
     assert result.skipped == []
-    assert collection.replace_one.call_count == 2
-    collection.update_one.assert_not_called()
+    head = collection.find_one({"_id": "sku"})
+    assert head["head_revision"] == 2
+    assert head["definition"]["root_mixins"] == []
+    revisions = list(
+        clean_schema_catalog_database.schema_revision.find(
+            {"schema_name": "sku"}
+        ).sort("revision")
+    )
+    assert [revision["revision"] for revision in revisions] == [1, 2]
+    assert revisions[0]["definition"]["root_mixins"] == [
+        "ItemTypeSelector"
+    ]
+    assert revisions[1]["parent_revision"] == 1
+
+
+def test_force_install_identical_content_is_a_no_op(
+    clean_schema_catalog_database,
+):
+    collection = clean_schema_catalog_database.schema
+    install_schemas(collection, {"sku": get_sku_schema})
+
+    result = install_schemas(
+        collection,
+        {"sku": get_sku_schema},
+        force=True,
+    )
+
+    assert result.installed == []
+    assert result.skipped == ["sku"]
+    assert clean_schema_catalog_database.schema_revision.count_documents(
+        {"schema_name": "sku"}
+    ) == 1

--- a/tests/test_schema_revisions.py
+++ b/tests/test_schema_revisions.py
@@ -1,0 +1,266 @@
+"""API and storage contracts for immutable dynamic-schema revisions."""
+
+from copy import deepcopy
+
+import pytest
+
+from inventorius.schema.repository import SchemaEditConflict, SchemaRepository
+from tests.database import get_test_database
+
+
+ACTOR = {"actor_id": "owner", "actor_type": "owner"}
+
+
+def schema_definition(*, field_name: str = "name"):
+    return {
+        "root_mixins": ["Base"],
+        "mixins": {
+            "Base": {
+                "name": "Base",
+                "fields": [{"name": field_name, "type": "text"}],
+                "children": [],
+            }
+        },
+        "intersections": [],
+    }
+
+
+@pytest.fixture(autouse=True)
+def clean_schema_revision_database():
+    database = get_test_database()
+    for name in ("schema", "schema_revision", "mutation_receipts"):
+        database[name].delete_many({})
+    yield database
+
+
+def test_create_and_identical_put_publish_only_one_revision(
+    client,
+    clean_schema_revision_database,
+):
+    definition = schema_definition()
+
+    assert client.put("/api/schema/component", json=definition).status_code == 200
+    assert client.put("/api/schema/component", json=definition).status_code == 200
+
+    head = clean_schema_revision_database.schema.find_one({
+        "_id": "component"
+    })
+    assert head == {
+        "_id": "component",
+        "head_revision": 1,
+        "active_revision": 1,
+        "definition": definition,
+    }
+    revision = clean_schema_revision_database.schema_revision.find_one({
+        "_id": {"schema_name": "component", "revision": 1}
+    })
+    assert revision["parent_revision"] is None
+    assert revision["actor"] == ACTOR
+    assert revision["published_at"] is not None
+    assert revision["compatibility"] == "unspecified"
+    assert revision["definition"] == definition
+    assert clean_schema_revision_database.mutation_receipts.count_documents({
+        "kind": "schema.save",
+        "target": "component",
+    }) == 1
+    assert client.get("/api/schema/component").json == definition
+
+
+def test_changed_put_preserves_history_and_historical_evaluation(
+    client,
+    clean_schema_revision_database,
+):
+    original = schema_definition(field_name="old_field")
+    changed = schema_definition(field_name="new_field")
+    assert client.put("/api/schema/component", json=original).status_code == 200
+    assert client.put("/api/schema/component", json=changed).status_code == 200
+
+    assert client.get("/api/schema/component").json == changed
+    assert client.get("/api/schema/component?revision=1").json == original
+    assert client.get("/api/schema/component?revision=2").json == changed
+    old_evaluation = client.post(
+        "/api/schema/component/evaluate?revision=1",
+        json={"active_mixins": ["Base"], "field_values": {}},
+    )
+    current_evaluation = client.post(
+        "/api/schema/component/evaluate",
+        json={"active_mixins": ["Base"], "field_values": {}},
+    )
+    assert old_evaluation.status_code == 200
+    assert [field["name"] for field in old_evaluation.json["available_fields"]] == [
+        "old_field"
+    ]
+    assert [
+        field["name"] for field in current_evaluation.json["available_fields"]
+    ] == ["new_field"]
+
+    revisions = list(
+        clean_schema_revision_database.schema_revision.find({
+            "schema_name": "component"
+        }).sort("revision")
+    )
+    assert [revision["revision"] for revision in revisions] == [1, 2]
+    assert revisions[1]["parent_revision"] == 1
+    assert revisions[0]["definition"] == original
+
+
+def test_mixin_and_root_mutations_each_publish_from_the_observed_head(
+    client,
+    clean_schema_revision_database,
+):
+    original = schema_definition()
+    assert client.put("/api/schema/component", json=original).status_code == 200
+    mixin = {
+        "name": "ignored-url-name-wins",
+        "fields": [{"name": "detail", "type": "text"}],
+        "children": [],
+    }
+
+    assert client.put(
+        "/api/schema/component/mixin/Extra",
+        json=mixin,
+    ).status_code == 200
+    assert client.put(
+        "/api/schema/component/root/Extra"
+    ).status_code == 200
+    assert client.delete(
+        "/api/schema/component/root/Extra"
+    ).status_code == 200
+    assert client.delete(
+        "/api/schema/component/mixin/Extra"
+    ).status_code == 200
+
+    head = clean_schema_revision_database.schema.find_one({
+        "_id": "component"
+    })
+    assert head["head_revision"] == 5
+    assert clean_schema_revision_database.schema_revision.count_documents({
+        "schema_name": "component"
+    }) == 5
+    assert "Extra" not in client.get("/api/schema/component?revision=1").json[
+        "mixins"
+    ]
+    revision_two = client.get("/api/schema/component?revision=2").json
+    assert revision_two["mixins"]["Extra"]["name"] == "Extra"
+    assert "Extra" not in revision_two["root_mixins"]
+    assert "Extra" in client.get("/api/schema/component?revision=3").json[
+        "root_mixins"
+    ]
+    assert "Extra" not in client.get("/api/schema/component").json["mixins"]
+
+
+def test_delete_deactivates_without_erasing_history_and_put_reactivates(
+    client,
+    clean_schema_revision_database,
+):
+    definition = schema_definition()
+    client.put("/api/schema/component", json=definition)
+
+    response = client.delete("/api/schema/component")
+
+    assert response.status_code == 200
+    assert client.get("/api/schema/component").status_code == 404
+    assert client.get("/api/schema/component?revision=1").json == definition
+    assert "component" not in client.get("/api/schema/list").json["schemas"]
+    head = clean_schema_revision_database.schema.find_one({
+        "_id": "component"
+    })
+    assert head["head_revision"] == 1
+    assert head["active_revision"] is None
+    assert clean_schema_revision_database.schema_revision.count_documents({
+        "schema_name": "component"
+    }) == 1
+
+    assert client.put("/api/schema/component", json=definition).status_code == 200
+    assert client.get("/api/schema/component").json == definition
+    assert clean_schema_revision_database.schema_revision.count_documents({
+        "schema_name": "component"
+    }) == 1
+
+
+def test_first_changed_legacy_publication_captures_exact_unknown_baseline(
+    client,
+    clean_schema_revision_database,
+):
+    original = schema_definition(field_name="legacy")
+    legacy_document = {
+        "_id": "component",
+        **deepcopy(original),
+        "legacy_note": "preserve this exact source document",
+    }
+    clean_schema_revision_database.schema.insert_one(legacy_document)
+
+    assert client.get("/api/schema/component").json == original
+    changed = schema_definition(field_name="published")
+    assert client.put("/api/schema/component", json=changed).status_code == 200
+
+    baseline = clean_schema_revision_database.schema_revision.find_one({
+        "_id": {"schema_name": "component", "revision": 1}
+    })
+    publication = clean_schema_revision_database.schema_revision.find_one({
+        "_id": {"schema_name": "component", "revision": 2}
+    })
+    assert baseline["definition"] == {
+        key: value for key, value in legacy_document.items() if key != "_id"
+    }
+    assert baseline["actor"] is None
+    assert baseline["published_at"] is None
+    assert baseline["compatibility"] == "unspecified"
+    assert publication["definition"] == changed
+    assert publication["parent_revision"] == 1
+    assert publication["actor"] == ACTOR
+    assert publication["published_at"] is not None
+    assert client.get("/api/schema/component?revision=1").json == original
+
+
+def test_deleting_a_legacy_schema_captures_baseline_before_deactivation(
+    client,
+    clean_schema_revision_database,
+):
+    original = schema_definition(field_name="legacy")
+    clean_schema_revision_database.schema.insert_one({
+        "_id": "component",
+        **deepcopy(original),
+    })
+
+    assert client.delete("/api/schema/component").status_code == 200
+
+    assert client.get("/api/schema/component").status_code == 404
+    assert client.get("/api/schema/component?revision=1").json == original
+    baseline = clean_schema_revision_database.schema_revision.find_one({
+        "_id": {"schema_name": "component", "revision": 1}
+    })
+    assert baseline["actor"] is None
+    assert baseline["published_at"] is None
+
+
+def test_stale_schema_head_is_rejected_by_compare_and_swap(
+    clean_schema_revision_database,
+):
+    repository = SchemaRepository(clean_schema_revision_database)
+    missing = repository.head("component")
+    repository.publish(
+        "component",
+        schema_definition(field_name="winner"),
+        actor=ACTOR,
+        expected=missing,
+    )
+
+    with pytest.raises(SchemaEditConflict):
+        repository.publish(
+            "component",
+            schema_definition(field_name="stale"),
+            actor=ACTOR,
+            expected=missing,
+        )
+
+    assert repository.definition("component") == schema_definition(
+        field_name="winner"
+    )
+
+
+@pytest.mark.parametrize("revision", ["nope", "0", "-1"])
+def test_historical_read_rejects_invalid_revision(client, revision):
+    response = client.get(f"/api/schema/component?revision={revision}")
+
+    assert response.status_code == 400


### PR DESCRIPTION
## Summary
- keep a small current schema head while publishing separate immutable revision documents
- use transaction-backed compare-and-swap publication and no-op identical content
- preserve exact legacy baselines with unknown historical actor/time
- expose optional exact historical reads and evaluation
- deactivate schemas without erasing history and make forced bootstrap publish changes

## Verification
- all 302 API tests passed against a temporary MongoDB replica set
- focused tests cover publication history, no-op writes, concurrent edit conflict, deactivation/reactivation, legacy capture, historical evaluation, and bootstrap

This foundation deliberately does not attach schema revisions to mutable SKU/Batch snapshots or define operational compatibility beyond the value unspecified.