### PR TITLE
Model process quantities across temporal and identity boundaries

### DIFF
--- a/docs/process-quantity-model.md
+++ b/docs/process-quantity-model.md
@@ -1,0 +1,67 @@
+# Process quantity model notes
+
+This is a persistence-free design checkpoint. It does not define MongoDB, HTTP,
+authorization, or frontend contracts.
+
+## Decisions represented
+
+- A process records only participating inputs and actual outputs. A source
+  remainder is a derived holding state, never a process output.
+- An input consumes either one exact amount or all quantity then feasible in one
+  exact holding.
+- An output may have an exact amount or reuse the compiled quantity of one
+  input. Move and whole-Batch reclassification use the latter relationship.
+- Every input must be accounted for by a holding output, an explicit external
+  sink, or a structural contribution to an output. The model deliberately
+  rejects a bare numerical withdrawal with no meaning.
+- Several same-unit, same-package candidate Batches may satisfy one observed SKU
+  selection. The compiler retains a latent allocation per candidate and one
+  shared total instead of selecting a Batch or storing independent ranges.
+- An audit produces non-consuming observations. Lower, upper, interval, exact,
+  and preferred-only claims remain distinct.
+- Assembly and disassembly use ordinary process inputs and outputs. Quantities
+  in incompatible units are not added; structural provenance remains a
+  separate relationship over the same process.
+- Definition edits and descriptive properties are ordinary database records,
+  outside the physical solver.
+- Process cost, Batch cost, FIFO, average cost, and other accounting policies
+  are a future projection over shared process identities and properties. They
+  do not change physical quantity algebra.
+- A late record is an ordinary process whose `occurred_at` precedes
+  `recorded_at`. The timeline recompiles by occurrence time and may expose a
+  contradiction in later history.
+- Correction and conflict-resolution semantics remain deliberately deferred.
+  The current experiment only retains and names contradictions.
+
+## Intentional limitations
+
+- Events with identical occurrence timestamps need an explicit causal-order
+  design before persistence; the experiment uses deterministic ordering only
+  so traces are reproducible.
+- External sources are not modeled yet, so output-only Receive processes fail
+  closed rather than manufacturing inventory from an unnamed source.
+- The compiler receives an explicit candidate set for ambiguous SKU selection.
+  A future identity/time resolver must determine those candidates from the SKU,
+  location, evidence, and occurrence time.
+- A process cannot consume from and produce into the identical holding in this
+  slice. That case needs explicit semantics instead of an accidental ordering.
+- An unresolved multi-Batch input cannot be collapsed into one concrete output
+  Batch. A later allocation/identity design must preserve those possibilities
+  through moves, splits, or transformations.
+- Process definitions, provenance allocation modes, corrections, database
+  codecs, and public operations remain outside this slice.
+- Generated holding states, flow variables, allocation variables, intervals,
+  witnesses, and conflicts are disposable projections. Only semantic events
+  are candidates for future persistence.
+
+## Running the traces
+
+From `inventorius-api`:
+
+```console
+uv run python scripts/trace_process_solver.py
+```
+
+The trace prints replay order, generated relationships, sharp current bounds,
+ambiguous per-Batch allocation, and the conflict caused by inserting a late
+process before otherwise consistent later events.

--- a/docs/process-quantity-model.md
+++ b/docs/process-quantity-model.md
@@ -23,6 +23,9 @@ authorization, or frontend contracts.
   add a Batch discovered later, while historical compilation retains the old
   candidate set. The compiler retains a latent allocation per candidate and one
   shared total instead of selecting a Batch or storing independent ranges.
+- An identity-preserving move maps every latent source allocation to a holding
+  of that same Batch at the destination. The moved total can therefore be exact
+  while the destination's per-Batch composition remains ranged.
 - An audit produces non-consuming observations. Lower, upper, interval, exact,
   and preferred-only claims remain distinct.
 - Assembly and disassembly use ordinary process inputs and outputs. Quantities
@@ -60,8 +63,8 @@ authorization, or frontend contracts.
 - A process cannot consume from and produce into the identical holding in this
   slice. That case needs explicit semantics instead of an accidental ordering.
 - An unresolved multi-Batch input cannot be collapsed into one concrete output
-  Batch. A later allocation/identity design must preserve those possibilities
-  through moves, splits, or transformations.
+  Batch. Identity-preserving moves now retain the alternatives; transformations
+  that merge, split, or replace those identities remain fail-closed.
 - Process definitions, provenance allocation modes, corrections, database
   codecs, and public operations remain outside this slice.
 - Batch replacement currently preserves location, unit, and package

--- a/docs/process-quantity-model.md
+++ b/docs/process-quantity-model.md
@@ -7,6 +7,9 @@ authorization, or frontend contracts.
 
 - A process records only participating inputs and actual outputs. A source
   remainder is a derived holding state, never a process output.
+- Receive crosses a named external-source boundary. Its quantity is an
+  observation with exact, bounded, or preferred evidence; it is not anonymous
+  creation and is linked algebraically to the received holding.
 - An input consumes either one exact amount or all quantity then feasible in one
   exact holding.
 - An output may have an exact amount or reuse the compiled quantity of one
@@ -15,7 +18,10 @@ authorization, or frontend contracts.
   sink, or a structural contribution to an output. The model deliberately
   rejects a bare numerical withdrawal with no meaning.
 - Several same-unit, same-package candidate Batches may satisfy one observed SKU
-  selection. The compiler retains a latent allocation per candidate and one
+  selection. The durable semantic fact is the SKU/location selection plus the
+  candidate snapshot known when it was recorded. A knowledge-aware resolver can
+  add a Batch discovered later, while historical compilation retains the old
+  candidate set. The compiler retains a latent allocation per candidate and one
   shared total instead of selecting a Batch or storing independent ranges.
 - An audit produces non-consuming observations. Lower, upper, interval, exact,
   and preferred-only claims remain distinct.
@@ -30,19 +36,27 @@ authorization, or frontend contracts.
 - A late record is an ordinary process whose `occurred_at` precedes
   `recorded_at`. The timeline recompiles by occurrence time and may expose a
   contradiction in later history.
+- Physical replay uses `(occurred_at, effective_order)`. Recording time filters
+  historical knowledge but never silently chooses physical order. Equal-time,
+  equal-order events may remain unordered only when their holdings are disjoint;
+  overlapping events fail closed.
+- Whole-Batch reclassification is retained as one Batch-replacement meaning and
+  expanded during replay across every then-current holding. A late-discovered
+  source holding is therefore reclassified on current-truth replay rather than
+  being permanently omitted from a frozen list of holding legs.
 - Correction and conflict-resolution semantics remain deliberately deferred.
   The current experiment only retains and names contradictions.
 
 ## Intentional limitations
 
-- Events with identical occurrence timestamps need an explicit causal-order
-  design before persistence; the experiment uses deterministic ordering only
-  so traces are reproducible.
-- External sources are not modeled yet, so output-only Receive processes fail
-  closed rather than manufacturing inventory from an unnamed source.
-- The compiler receives an explicit candidate set for ambiguous SKU selection.
-  A future identity/time resolver must determine those candidates from the SKU,
-  location, evidence, and occurrence time.
+- `effective_order` is a deliberately small ordering mechanism, not a final
+  claim that integer sequence numbers will be sufficient for concurrent or
+  partially ordered physical histories.
+- One external source feeds one output in this slice. Split receipts and
+  multi-output boundary allocation still need explicit flow semantics.
+- The experiment defines the knowledge-aware candidate-resolver seam, not the
+  database implementation that will resolve SKU membership and presence at the
+  event's occurrence time.
 - A process cannot consume from and produce into the identical holding in this
   slice. That case needs explicit semantics instead of an accidental ordering.
 - An unresolved multi-Batch input cannot be collapsed into one concrete output
@@ -50,6 +64,9 @@ authorization, or frontend contracts.
   through moves, splits, or transformations.
 - Process definitions, provenance allocation modes, corrections, database
   codecs, and public operations remain outside this slice.
+- Batch replacement currently preserves location, unit, and package
+  configuration. Reclassification that also changes those dimensions should be
+  an ordinary explicit transformation, not hidden inside identity replacement.
 - Generated holding states, flow variables, allocation variables, intervals,
   witnesses, and conflicts are disposable projections. Only semantic events
   are candidates for future persistence.

--- a/scripts/trace_process_solver.py
+++ b/scripts/trace_process_solver.py
@@ -11,6 +11,7 @@ from inventorius.process_quantities import (
     FromInput,
     FromSource,
     ObservationEvent,
+    PreservedIdentityOutput,
     ProcessEvent,
     ProcessInput,
     ProcessOutput,
@@ -183,6 +184,53 @@ def audit_trace():
     show("Audit: later upper bound", timeline, (("bolts", holding),))
     timeline.record(exact("OBS-complete-count", holding, 25, 3))
     show("Audit: complete count", timeline, (("bolts", holding),))
+
+
+def ambiguous_move_trace():
+    first_source = HoldingKey("BAT-A", "BIN-A", "each")
+    second_source = HoldingKey("BAT-B", "BIN-A", "each")
+    first_destination = HoldingKey("BAT-A", "BIN-B", "each")
+    second_destination = HoldingKey("BAT-B", "BIN-B", "each")
+    timeline = ProcessQuantityTimeline()
+    timeline.record(exact("OBS-A-ten-move", first_source, 10, 1))
+    timeline.record(exact("OBS-B-ten-move", second_source, 10, 1))
+    timeline.record(ProcessEvent(
+        "PROC-ambiguous-move",
+        "move",
+        time(2),
+        time(2),
+        inputs=(ProcessInput(
+            "moved",
+            (first_source, second_source),
+            ExactAmount(5),
+            selector=selection(
+                "SEL-move-fasteners",
+                "SKU-FASTENER",
+                "BIN-A",
+                first_source,
+                second_source,
+            ),
+        ),),
+        preserved_outputs=(PreservedIdentityOutput(
+            "destination",
+            "moved",
+            "BIN-B",
+        ),),
+    ))
+    compiled = show(
+        "Ambiguous move preserves possible Batch identities",
+        timeline,
+        (
+            ("Batch A source", first_source),
+            ("Batch B source", second_source),
+            ("Batch A destination", first_destination),
+            ("Batch B destination", second_destination),
+        ),
+    )
+    destination_total = compiled.current_total_bounds(
+        (first_destination, second_destination)
+    )
+    print(f"  combined destination: {amount(destination_total)} each")
 
 
 def reclassification_trace():
@@ -415,6 +463,7 @@ def late_conflict_trace():
 def main():
     move_trace()
     ambiguous_trace()
+    ambiguous_move_trace()
     audit_trace()
     receive_trace()
     reclassification_trace()

--- a/scripts/trace_process_solver.py
+++ b/scripts/trace_process_solver.py
@@ -5,15 +5,18 @@ from datetime import datetime, timezone
 
 from inventorius.ledger import HoldingKey
 from inventorius.process_quantities import (
-    ALL_REMAINING,
+    BatchReplacement,
+    CandidateSelection,
     ExactAmount,
     FromInput,
+    FromSource,
     ObservationEvent,
     ProcessEvent,
     ProcessInput,
     ProcessOutput,
     ProcessQuantityTimeline,
     ProcessSink,
+    ProcessSource,
 )
 from inventorius.quantity_constraints import (
     InfeasibleQuantityFacts,
@@ -48,6 +51,16 @@ def amount(bounds) -> str:
     low = "unbounded" if bounds.minimum is None else str(bounds.minimum)
     high = "unbounded" if bounds.maximum is None else str(bounds.maximum)
     return low if low == high else f"{low}..{high}"
+
+
+def selection(selection_id, sku_id, location_id, *candidates):
+    return CandidateSelection(
+        selection_id,
+        sku_id,
+        location_id,
+        candidates[0].unit,
+        candidates[0].packaging_configuration_id,
+    )
 
 
 def show(title: str, timeline: ProcessQuantityTimeline, holdings=()):
@@ -106,7 +119,13 @@ def ambiguous_trace():
             "fasteners",
             (first, second),
             ExactAmount(5),
-            selector="SKU-FASTENER observed in BIN-SHARED",
+            selector=selection(
+                "SEL-fasteners",
+                "SKU-FASTENER",
+                "BIN-SHARED",
+                first,
+                second,
+            ),
         ),),
         sinks=(ProcessSink(
             "project",
@@ -168,7 +187,9 @@ def audit_trace():
 
 def reclassification_trace():
     old = HoldingKey("BAT-WRONG", "BIN-PARTS", "each")
+    old_bench = HoldingKey("BAT-WRONG", "BENCH", "each")
     new = HoldingKey("BAT-CORRECT", "BIN-PARTS", "each")
+    new_bench = HoldingKey("BAT-CORRECT", "BENCH", "each")
     timeline = ProcessQuantityTimeline()
     timeline.record(ObservationEvent(
         old,
@@ -183,21 +204,131 @@ def reclassification_trace():
         time(1),
         time(1),
     ))
+    timeline.record(exact("OBS-old-bench", old_bench, 3, 1))
     timeline.record(ProcessEvent(
         "PROC-reclassify",
         "reclassify",
         time(2),
         time(2),
-        inputs=(ProcessInput("old-batch", (old,), ALL_REMAINING),),
-        outputs=(ProcessOutput(
-            "new-batch", new, DISCRETE, FromInput("old-batch")
+        batch_replacements=(BatchReplacement(
+            "replace-identity",
+            "BAT-WRONG",
+            "BAT-CORRECT",
         ),),
     ))
     show(
         "Whole-Batch reclassification",
         timeline,
-        (("old Batch", old), ("new Batch", new)),
+        (
+            ("old Batch in bin", old),
+            ("old Batch on bench", old_bench),
+            ("new Batch in bin", new),
+            ("new Batch on bench", new_bench),
+        ),
     )
+
+
+def receive_trace():
+    holding = HoldingKey("BAT-LIQUID", "SHELF", "milliliter")
+    timeline = ProcessQuantityTimeline()
+    timeline.record(ProcessEvent(
+        "PROC-receive-liquid",
+        "receive",
+        time(1),
+        time(1),
+        sources=(ProcessSource(
+            "supplier-bottle",
+            "supplier shipment",
+            "milliliter",
+            QuantityDomain.CONTINUOUS,
+            QuantityObservation.estimated("OBS-bottle-estimate", 50),
+        ),),
+        outputs=(ProcessOutput(
+            "received-bottle",
+            holding,
+            QuantityDomain.CONTINUOUS,
+            FromSource("supplier-bottle"),
+        ),),
+    ))
+    show(
+        "Receive crosses an explicit external boundary",
+        timeline,
+        (("received liquid", holding),),
+    )
+
+
+def late_candidate_trace():
+    first = HoldingKey("BAT-A", "BIN-SHARED", "each")
+    second = HoldingKey("BAT-B", "BIN-SHARED", "each")
+    late = HoldingKey("BAT-C", "BIN-SHARED", "each")
+    selector = selection(
+        "SEL-shared-fasteners",
+        "SKU-FASTENER",
+        "BIN-SHARED",
+        first,
+        second,
+    )
+    timeline = ProcessQuantityTimeline()
+    timeline.record(exact("OBS-A-two", first, 2, 1))
+    timeline.record(exact("OBS-B-two", second, 2, 1))
+    timeline.record(ObservationEvent(
+        late,
+        DISCRETE,
+        QuantityObservation.exact(
+            "OBS-C-two-recorded-late",
+            2,
+            basis=ObservationBasis.COUNTED,
+        ),
+        time(1),
+        time(3),
+    ))
+    timeline.record(ProcessEvent(
+        "PROC-take-three",
+        "consume",
+        time(2),
+        time(2),
+        inputs=(ProcessInput(
+            "fasteners",
+            (first, second),
+            ExactAmount(3),
+            selector=selector,
+        ),),
+        sinks=(ProcessSink(
+            "project",
+            "consumed by project",
+            "each",
+            DISCRETE,
+            FromInput("fasteners"),
+        ),),
+    ))
+
+    def resolve(
+        candidate_selection,
+        candidates_at_recording,
+        occurred_at,
+        known_at,
+    ):
+        return (first, second, late) if known_at is None else (first, second)
+
+    historical = timeline.compile(
+        known_at=time(2, 13),
+        candidate_resolver=resolve,
+    )
+    current = timeline.compile(candidate_resolver=resolve)
+    print("\n=== Late Batch discovery changes possibilities, not the observation ===")
+    print(
+        "  historical candidate remainder: "
+        f"{amount(historical.current_total_bounds((first, second)))} each"
+    )
+    print(
+        "  current candidate remainder: "
+        f"{amount(current.current_total_bounds((first, second, late)))} each"
+    )
+    for label, holding in (("Batch A", first), ("Batch B", second), ("Batch C", late)):
+        print(
+            f"  current possible draw from {label}: "
+            f"{amount(current.allocation_bounds('PROC-take-three', 'fasteners', holding))} each"
+        )
 
 
 def assembly_trace():
@@ -285,7 +416,9 @@ def main():
     move_trace()
     ambiguous_trace()
     audit_trace()
+    receive_trace()
     reclassification_trace()
+    late_candidate_trace()
     assembly_trace()
     late_conflict_trace()
 

--- a/scripts/trace_process_solver.py
+++ b/scripts/trace_process_solver.py
@@ -1,0 +1,294 @@
+#!/usr/bin/env python3
+"""Print concrete process/observation traces from the experimental compiler."""
+
+from datetime import datetime, timezone
+
+from inventorius.ledger import HoldingKey
+from inventorius.process_quantities import (
+    ALL_REMAINING,
+    ExactAmount,
+    FromInput,
+    ObservationEvent,
+    ProcessEvent,
+    ProcessInput,
+    ProcessOutput,
+    ProcessQuantityTimeline,
+    ProcessSink,
+)
+from inventorius.quantity_constraints import (
+    InfeasibleQuantityFacts,
+    ObservationBasis,
+    QuantityDomain,
+    QuantityObservation,
+)
+
+
+DISCRETE = QuantityDomain.DISCRETE
+
+
+def time(day: int, hour: int = 12) -> datetime:
+    return datetime(2026, 8, day, hour, tzinfo=timezone.utc)
+
+
+def exact(event_id: str, holding: HoldingKey, amount: int, day: int):
+    return ObservationEvent(
+        holding,
+        DISCRETE,
+        QuantityObservation.exact(
+            event_id,
+            amount,
+            basis=ObservationBasis.COUNTED,
+        ),
+        time(day),
+        time(day),
+    )
+
+
+def amount(bounds) -> str:
+    low = "unbounded" if bounds.minimum is None else str(bounds.minimum)
+    high = "unbounded" if bounds.maximum is None else str(bounds.maximum)
+    return low if low == high else f"{low}..{high}"
+
+
+def show(title: str, timeline: ProcessQuantityTimeline, holdings=()):
+    compiled = timeline.compile()
+    print(f"\n=== {title} ===")
+    print("Replay order: " + " -> ".join(compiled.event_order))
+    print("Generated relationships:")
+    for relation in compiled.rendered_constraints():
+        print(f"  {relation}")
+    print("Result:")
+    if not compiled.is_feasible():
+        print("  CONFLICT: " + ", ".join(compiled.conflict()))
+    for label, holding in holdings:
+        try:
+            rendered = amount(compiled.current_bounds(holding))
+        except InfeasibleQuantityFacts:
+            rendered = "no feasible quantity"
+        print(f"  {label}: {rendered} {holding.unit}")
+    return compiled
+
+
+def move_trace():
+    source = HoldingKey("BAT-SCREW", "BIN-A", "each")
+    destination = HoldingKey("BAT-SCREW", "BIN-B", "each")
+    timeline = ProcessQuantityTimeline()
+    timeline.record(exact("OBS-ten", source, 10, 1))
+    timeline.record(ProcessEvent(
+        "PROC-move-three",
+        "move",
+        time(2),
+        time(2),
+        inputs=(ProcessInput("moved", (source,), ExactAmount(3)),),
+        outputs=(ProcessOutput(
+            "destination", destination, DISCRETE, FromInput("moved")
+        ),),
+    ))
+    show(
+        "Move consumes only the participating quantity",
+        timeline,
+        (("source remainder (derived)", source), ("destination", destination)),
+    )
+
+
+def ambiguous_trace():
+    first = HoldingKey("BAT-A", "BIN-SHARED", "each")
+    second = HoldingKey("BAT-B", "BIN-SHARED", "each")
+    timeline = ProcessQuantityTimeline()
+    timeline.record(exact("OBS-A-ten", first, 10, 1))
+    timeline.record(exact("OBS-B-ten", second, 10, 1))
+    timeline.record(ProcessEvent(
+        "PROC-take-five",
+        "consume",
+        time(2),
+        time(2),
+        inputs=(ProcessInput(
+            "fasteners",
+            (first, second),
+            ExactAmount(5),
+            selector="SKU-FASTENER observed in BIN-SHARED",
+        ),),
+        sinks=(ProcessSink(
+            "project",
+            "consumed by project",
+            "each",
+            DISCRETE,
+            FromInput("fasteners"),
+        ),),
+    ))
+    compiled = show(
+        "Same SKU and Bin, source Batch unknown",
+        timeline,
+        (("Batch A", first), ("Batch B", second)),
+    )
+    print(
+        "  combined remainder: "
+        f"{amount(compiled.current_total_bounds((first, second)))} each"
+    )
+    print(
+        "  possible draw from Batch A: "
+        f"{amount(compiled.allocation_bounds('PROC-take-five', 'fasteners', first))} each"
+    )
+    print(
+        "  possible draw from Batch B: "
+        f"{amount(compiled.allocation_bounds('PROC-take-five', 'fasteners', second))} each"
+    )
+
+
+def audit_trace():
+    holding = HoldingKey("BAT-BOLTS", "BIN-AUDIT", "each")
+    timeline = ProcessQuantityTimeline()
+    timeline.record(ObservationEvent(
+        holding,
+        DISCRETE,
+        QuantityObservation(
+            "OBS-saw-ten",
+            lower=10,
+            basis=ObservationBasis.COUNTED,
+        ),
+        time(1),
+        time(1),
+    ))
+    show("Audit: saw at least ten", timeline, (("bolts", holding),))
+    timeline.record(ObservationEvent(
+        holding,
+        DISCRETE,
+        QuantityObservation(
+            "OBS-capacity-forty",
+            upper=40,
+            basis=ObservationBasis.MEASURED,
+        ),
+        time(2),
+        time(2),
+    ))
+    show("Audit: later upper bound", timeline, (("bolts", holding),))
+    timeline.record(exact("OBS-complete-count", holding, 25, 3))
+    show("Audit: complete count", timeline, (("bolts", holding),))
+
+
+def reclassification_trace():
+    old = HoldingKey("BAT-WRONG", "BIN-PARTS", "each")
+    new = HoldingKey("BAT-CORRECT", "BIN-PARTS", "each")
+    timeline = ProcessQuantityTimeline()
+    timeline.record(ObservationEvent(
+        old,
+        DISCRETE,
+        QuantityObservation(
+            "OBS-old-estimate",
+            lower=8,
+            preferred=10,
+            upper=12,
+            basis=ObservationBasis.ESTIMATED,
+        ),
+        time(1),
+        time(1),
+    ))
+    timeline.record(ProcessEvent(
+        "PROC-reclassify",
+        "reclassify",
+        time(2),
+        time(2),
+        inputs=(ProcessInput("old-batch", (old,), ALL_REMAINING),),
+        outputs=(ProcessOutput(
+            "new-batch", new, DISCRETE, FromInput("old-batch")
+        ),),
+    ))
+    show(
+        "Whole-Batch reclassification",
+        timeline,
+        (("old Batch", old), ("new Batch", new)),
+    )
+
+
+def assembly_trace():
+    screws = HoldingKey("BAT-SCREWS", "BIN-SCREWS", "each")
+    body = HoldingKey("BAT-BODY", "BIN-BODIES", "each")
+    machine = HoldingKey("BAT-MACHINE", "BENCH", "each")
+    timeline = ProcessQuantityTimeline()
+    timeline.record(exact("OBS-screws-twenty", screws, 20, 1))
+    timeline.record(exact("OBS-one-body", body, 1, 1))
+    timeline.record(ProcessEvent(
+        "PROC-assemble",
+        "assembly",
+        time(2),
+        time(2),
+        inputs=(
+            ProcessInput(
+                "fasteners",
+                (screws,),
+                ExactAmount(4),
+                "fasteners",
+                contributes_to=("machine",),
+            ),
+            ProcessInput(
+                "body",
+                (body,),
+                ExactAmount(1),
+                "machine body",
+                contributes_to=("machine",),
+            ),
+        ),
+        outputs=(ProcessOutput(
+            "machine",
+            machine,
+            DISCRETE,
+            ExactAmount(1),
+            "assembled machine",
+        ),),
+    ))
+    show(
+        "Assembly uses ordinary inputs and outputs",
+        timeline,
+        (("unused screws", screws), ("unused bodies", body), ("machine", machine)),
+    )
+
+
+def late_conflict_trace():
+    source = HoldingKey("BAT-LATE", "BIN-A", "each")
+    moved = HoldingKey("BAT-LATE", "BIN-B", "each")
+    timeline = ProcessQuantityTimeline()
+    timeline.record(exact("OBS-opening-ten", source, 10, 1))
+    timeline.record(ProcessEvent(
+        "PROC-move-six",
+        "move",
+        time(3),
+        time(3),
+        inputs=(ProcessInput("moved", (source,), ExactAmount(6)),),
+        outputs=(ProcessOutput(
+            "destination", moved, DISCRETE, FromInput("moved")
+        ),),
+    ))
+    timeline.record(exact("OBS-four-remain", source, 4, 4))
+    show("History before late recording", timeline, (("source", source),))
+    timeline.record(ProcessEvent(
+        "PROC-late-five",
+        "consume",
+        time(2),
+        time(5),
+        inputs=(ProcessInput("consumed", (source,), ExactAmount(5)),),
+        sinks=(ProcessSink(
+            "unknown-use",
+            "late-recorded consumption",
+            "each",
+            DISCRETE,
+            FromInput("consumed"),
+        ),),
+    ))
+    show(
+        "Late process inserted before later events",
+        timeline,
+        (("source", source), ("moved destination", moved)),
+    )
+
+
+def main():
+    move_trace()
+    ambiguous_trace()
+    audit_trace()
+    reclassification_trace()
+    assembly_trace()
+    late_conflict_trace()
+
+
+if __name__ == "__main__":
+    main()

--- a/src/inventorius/process_quantities.py
+++ b/src/inventorius/process_quantities.py
@@ -16,7 +16,8 @@ from __future__ import annotations
 from dataclasses import dataclass
 from datetime import datetime
 from fractions import Fraction
-from typing import Sequence
+from itertools import groupby
+from typing import Callable, Sequence
 
 from inventorius.ledger import HoldingKey
 from inventorius.quantity_constraints import (
@@ -91,8 +92,44 @@ class FromInput:
         _nonblank(self.input_id, "input_id")
 
 
+@dataclass(frozen=True)
+class FromSource:
+    """Produce exactly the quantity admitted through one external boundary."""
+
+    source_id: str
+
+    def __post_init__(self) -> None:
+        _nonblank(self.source_id, "source_id")
+
+
+@dataclass(frozen=True)
+class CandidateSelection:
+    """The observed SKU/location query behind an unresolved Batch choice.
+
+    The enclosing ``ProcessInput.candidates`` preserves what the recorder could
+    identify at the time. A knowledge-aware resolver may later return a
+    different set without rewriting the physical observation into an arbitrary
+    Batch fact.
+    """
+
+    selection_id: str
+    sku_id: str
+    location_id: str
+    unit: str
+    packaging_configuration_id: str | None = None
+
+    def __post_init__(self) -> None:
+        _nonblank(self.selection_id, "selection_id")
+        _nonblank(self.sku_id, "sku_id")
+        _nonblank(self.location_id, "location_id")
+        _nonblank(self.unit, "unit")
 InputAmount = ExactAmount | AllRemaining
-OutputAmount = ExactAmount | FromInput
+OutputAmount = ExactAmount | FromInput | FromSource
+
+CandidateResolver = Callable[
+    [CandidateSelection, tuple[HoldingKey, ...], datetime, datetime | None],
+    Sequence[HoldingKey],
+]
 
 
 @dataclass(frozen=True)
@@ -103,7 +140,7 @@ class ProcessInput:
     candidates: tuple[HoldingKey, ...]
     amount: InputAmount
     role: str = "input"
-    selector: str | None = None
+    selector: CandidateSelection | None = None
     contributes_to: tuple[str, ...] = ()
 
     def __post_init__(self) -> None:
@@ -117,10 +154,22 @@ class ProcessInput:
             raise ValueError("process input amount has an unsupported type")
         if isinstance(self.amount, AllRemaining) and len(self.candidates) != 1:
             raise ValueError("all remaining requires one exact holding")
-        if len(self.candidates) > 1:
-            _nonblank(self.selector, "selector")
-        elif self.selector is not None:
-            _nonblank(self.selector, "selector")
+        if len(self.candidates) > 1 and self.selector is None:
+            raise ValueError("ambiguous input needs its observed selection")
+        if self.selector is not None:
+            if not isinstance(self.selector, CandidateSelection):
+                raise ValueError("selector must be a CandidateSelection")
+            for holding in self.candidates:
+                if (
+                    holding.location_id != self.selector.location_id
+                    or holding.unit != self.selector.unit
+                    or holding.packaging_configuration_id
+                    != self.selector.packaging_configuration_id
+                ):
+                    raise ValueError(
+                        "input candidates must match the selection location, "
+                        "unit, and package configuration"
+                    )
         if len(set(self.contributes_to)) != len(self.contributes_to):
             raise ValueError("contributes_to output identifiers must be distinct")
         for output_id in self.contributes_to:
@@ -144,8 +193,46 @@ class ProcessOutput:
             raise ValueError("process output holding must be a HoldingKey")
         if not isinstance(self.domain, QuantityDomain):
             raise ValueError("process output domain must be a QuantityDomain")
-        if not isinstance(self.amount, (ExactAmount, FromInput)):
+        if not isinstance(self.amount, (ExactAmount, FromInput, FromSource)):
             raise ValueError("process output amount has an unsupported type")
+
+
+@dataclass(frozen=True)
+class ProcessSource:
+    """A named external boundary admitting quantity into tracked holdings."""
+
+    source_id: str
+    kind: str
+    unit: str
+    domain: QuantityDomain
+    observation: QuantityObservation
+    note: str = ""
+
+    def __post_init__(self) -> None:
+        _nonblank(self.source_id, "source_id")
+        _nonblank(self.kind, "kind")
+        _nonblank(self.unit, "unit")
+        if not isinstance(self.domain, QuantityDomain):
+            raise ValueError("process source domain must be a QuantityDomain")
+        if not isinstance(self.observation, QuantityObservation):
+            raise ValueError("process source needs a quantity observation")
+        _validate_observation(self.domain, self.observation)
+
+
+@dataclass(frozen=True)
+class BatchReplacement:
+    """Replace one Batch identity everywhere it is held at this point in time."""
+
+    replacement_id: str
+    source_batch_id: str
+    destination_batch_id: str
+
+    def __post_init__(self) -> None:
+        _nonblank(self.replacement_id, "replacement_id")
+        _nonblank(self.source_batch_id, "source_batch_id")
+        _nonblank(self.destination_batch_id, "destination_batch_id")
+        if self.source_batch_id == self.destination_batch_id:
+            raise ValueError("a Batch replacement needs two distinct identities")
 
 
 @dataclass(frozen=True)
@@ -180,7 +267,10 @@ class ProcessEvent:
     inputs: tuple[ProcessInput, ...] = ()
     outputs: tuple[ProcessOutput, ...] = ()
     sinks: tuple[ProcessSink, ...] = ()
+    sources: tuple[ProcessSource, ...] = ()
+    batch_replacements: tuple[BatchReplacement, ...] = ()
     note: str = ""
+    effective_order: int = 0
 
     def __post_init__(self) -> None:
         _nonblank(self.process_id, "process_id")
@@ -189,19 +279,36 @@ class ProcessEvent:
         recorded = _aware(self.recorded_at, "recorded_at")
         if recorded < occurred:
             raise ValueError("recorded_at cannot precede occurred_at")
-        if not self.inputs:
+        if (
+            isinstance(self.effective_order, bool)
+            or not isinstance(self.effective_order, int)
+            or self.effective_order < 0
+        ):
+            raise ValueError("effective_order must be a nonnegative integer")
+        if not self.inputs and not self.sources and not self.batch_replacements:
             raise ValueError(
                 "output-only processes need explicit external-source semantics"
             )
+        if self.batch_replacements and (
+            self.inputs or self.outputs or self.sinks or self.sources
+        ):
+            raise ValueError(
+                "Batch replacement is an exclusive semantic process in this slice"
+            )
+        if len(self.batch_replacements) > 1:
+            raise ValueError("one process may replace only one Batch in this slice")
         input_ids = [item.input_id for item in self.inputs]
         output_ids = [item.output_id for item in self.outputs]
         sink_ids = [item.sink_id for item in self.sinks]
+        source_ids = [item.source_id for item in self.sources]
         if len(set(input_ids)) != len(input_ids):
             raise ValueError("process input identifiers must be distinct")
         if len(set(output_ids)) != len(output_ids):
             raise ValueError("process output identifiers must be distinct")
         if len(set(sink_ids)) != len(sink_ids):
             raise ValueError("process sink identifiers must be distinct")
+        if len(set(source_ids)) != len(source_ids):
+            raise ValueError("process source identifiers must be distinct")
         known_inputs = set(input_ids)
         for output in self.outputs:
             if (
@@ -220,6 +327,11 @@ class ProcessEvent:
                         "an ambiguous input cannot become one concrete output "
                         "Batch without allocation semantics"
                     )
+            if (
+                isinstance(output.amount, FromSource)
+                and output.amount.source_id not in set(source_ids)
+            ):
+                raise ValueError("process output references an unknown source")
         for sink in self.sinks:
             if sink.amount.input_id not in known_inputs:
                 raise ValueError("process sink references an unknown input")
@@ -240,6 +352,17 @@ class ProcessEvent:
                 raise ValueError(
                     "every process input needs an output, sink, or structural "
                     "contribution"
+                )
+        for source_id in source_ids:
+            references = [
+                output
+                for output in self.outputs
+                if isinstance(output.amount, FromSource)
+                and output.amount.source_id == source_id
+            ]
+            if len(references) != 1:
+                raise ValueError(
+                    "each external source must feed exactly one output in this slice"
                 )
         touched_inputs = [
             holding for item in self.inputs for holding in item.candidates
@@ -264,6 +387,7 @@ class ObservationEvent:
     observation: QuantityObservation
     occurred_at: datetime
     recorded_at: datetime
+    effective_order: int = 0
 
     def __post_init__(self) -> None:
         if not isinstance(self.holding, HoldingKey):
@@ -276,6 +400,12 @@ class ObservationEvent:
         recorded = _aware(self.recorded_at, "recorded_at")
         if recorded < occurred:
             raise ValueError("recorded_at cannot precede occurred_at")
+        if (
+            isinstance(self.effective_order, bool)
+            or not isinstance(self.effective_order, int)
+            or self.effective_order < 0
+        ):
+            raise ValueError("effective_order must be a nonnegative integer")
 
     @property
     def event_id(self) -> str:
@@ -310,6 +440,7 @@ class ProcessQuantityTimeline:
         self,
         *,
         known_at: datetime | None = None,
+        candidate_resolver: CandidateResolver | None = None,
     ) -> CompiledProcessQuantities:
         if known_at is not None:
             _aware(known_at, "known_at")
@@ -321,11 +452,15 @@ class ProcessQuantityTimeline:
         events.sort(
             key=lambda event: (
                 event.occurred_at,
-                event.recorded_at,
+                event.effective_order,
                 _event_id(event),
             )
         )
-        return _ProcessCompiler(self._query_timeout_ms).compile(events)
+        return _ProcessCompiler(
+            self._query_timeout_ms,
+            known_at=known_at,
+            candidate_resolver=candidate_resolver,
+        ).compile(events)
 
 
 class CompiledProcessQuantities:
@@ -337,6 +472,8 @@ class CompiledProcessQuantities:
         current: dict[HoldingKey, HoldingState],
         input_variables: dict[tuple[str, str], str],
         allocation_variables: dict[tuple[str, str, HoldingKey], str],
+        source_variables: dict[tuple[str, str], str],
+        replacement_holdings: dict[str, tuple[tuple[HoldingKey, HoldingKey], ...]],
         labels: dict[str, str],
         event_order: tuple[str, ...],
     ) -> None:
@@ -344,6 +481,8 @@ class CompiledProcessQuantities:
         self._current = current
         self._input_variables = input_variables
         self._allocation_variables = allocation_variables
+        self._source_variables = source_variables
+        self._replacement_holdings = replacement_holdings
         self._labels = labels
         self._event_order = event_order
 
@@ -424,6 +563,22 @@ class CompiledProcessQuantities:
             ) from error
         return self._system.bounds(variable_id)
 
+    def source_bounds(self, process_id: str, source_id: str) -> QuantityBounds:
+        try:
+            variable_id = self._source_variables[(process_id, source_id)]
+        except KeyError as error:
+            raise ValueError("process source has no compiled quantity") from error
+        return self._system.bounds(variable_id)
+
+    def replacement_holdings(
+        self,
+        process_id: str,
+    ) -> tuple[tuple[HoldingKey, HoldingKey], ...]:
+        try:
+            return self._replacement_holdings[process_id]
+        except KeyError as error:
+            raise ValueError("process has no compiled Batch replacement") from error
+
     def rendered_constraints(self) -> tuple[str, ...]:
         """Return readable algebra without exposing generated Z3 expressions."""
 
@@ -435,7 +590,13 @@ class CompiledProcessQuantities:
 
 
 class _ProcessCompiler:
-    def __init__(self, timeout_ms: int) -> None:
+    def __init__(
+        self,
+        timeout_ms: int,
+        *,
+        known_at: datetime | None,
+        candidate_resolver: CandidateResolver | None,
+    ) -> None:
         self._system = QuantityConstraintSystem(timeout_ms=timeout_ms)
         self._current: dict[HoldingKey, HoldingState] = {}
         self._revisions: dict[HoldingKey, int] = {}
@@ -443,27 +604,133 @@ class _ProcessCompiler:
         self._allocation_variables: dict[
             tuple[str, str, HoldingKey], str
         ] = {}
+        self._source_variables: dict[tuple[str, str], str] = {}
+        self._replacement_holdings: dict[
+            str, tuple[tuple[HoldingKey, HoldingKey], ...]
+        ] = {}
         self._labels: dict[str, str] = {}
+        self._known_at = known_at
+        self._candidate_resolver = candidate_resolver
 
     def compile(
         self,
         events: Sequence[QuantityEvent],
     ) -> CompiledProcessQuantities:
         order = []
-        for event in events:
-            order.append(_event_id(event))
-            if isinstance(event, ObservationEvent):
-                self._compile_observation(event)
-            else:
-                self._compile_process(event)
+        for _, simultaneous in groupby(
+            events,
+            key=lambda event: (event.occurred_at, event.effective_order),
+        ):
+            group = tuple(simultaneous)
+            resolved = self._resolve_group_candidates(group)
+            self._reject_overlapping_simultaneous_events(group, resolved)
+            for event in group:
+                order.append(_event_id(event))
+                if isinstance(event, ObservationEvent):
+                    self._compile_observation(event)
+                else:
+                    self._compile_process(event, resolved)
         return CompiledProcessQuantities(
             self._system,
             dict(self._current),
             dict(self._input_variables),
             dict(self._allocation_variables),
+            dict(self._source_variables),
+            dict(self._replacement_holdings),
             dict(self._labels),
             tuple(order),
         )
+
+    def _resolve_group_candidates(
+        self,
+        events: Sequence[QuantityEvent],
+    ) -> dict[tuple[str, str], tuple[HoldingKey, ...]]:
+        resolved: dict[tuple[str, str], tuple[HoldingKey, ...]] = {}
+        for event in events:
+            if not isinstance(event, ProcessEvent):
+                continue
+            for process_input in event.inputs:
+                candidates: Sequence[HoldingKey] = process_input.candidates
+                if (
+                    process_input.selector is not None
+                    and self._candidate_resolver is not None
+                ):
+                    candidates = self._candidate_resolver(
+                        process_input.selector,
+                        process_input.candidates,
+                        event.occurred_at,
+                        self._known_at,
+                    )
+                normalized = tuple(candidates)
+                if not normalized:
+                    raise ValueError("candidate resolver returned no holdings")
+                if len(set(normalized)) != len(normalized):
+                    raise ValueError("candidate resolver returned duplicate holdings")
+                selector = process_input.selector
+                if selector is not None:
+                    for holding in normalized:
+                        if (
+                            holding.location_id != selector.location_id
+                            or holding.unit != selector.unit
+                            or holding.packaging_configuration_id
+                            != selector.packaging_configuration_id
+                        ):
+                            raise ValueError(
+                                "resolved candidates must match the observed "
+                                "selection location, unit, and package configuration"
+                            )
+                if (
+                    isinstance(process_input.amount, AllRemaining)
+                    and len(normalized) != 1
+                ):
+                    raise ValueError(
+                        "all remaining requires one resolved exact holding"
+                    )
+                resolved[(event.process_id, process_input.input_id)] = normalized
+        return resolved
+
+    def _reject_overlapping_simultaneous_events(
+        self,
+        events: Sequence[QuantityEvent],
+        resolved: dict[tuple[str, str], tuple[HoldingKey, ...]],
+    ) -> None:
+        touched: list[tuple[str, set[HoldingKey]]] = []
+        for event in events:
+            holdings: set[HoldingKey]
+            if isinstance(event, ObservationEvent):
+                holdings = {event.holding}
+            else:
+                holdings = {
+                    holding
+                    for process_input in event.inputs
+                    for holding in resolved[
+                        (event.process_id, process_input.input_id)
+                    ]
+                }
+                holdings.update(output.holding for output in event.outputs)
+                for replacement in event.batch_replacements:
+                    for current_holding in self._current:
+                        if current_holding.batch_id in {
+                            replacement.source_batch_id,
+                            replacement.destination_batch_id,
+                        }:
+                            holdings.add(current_holding)
+                            holdings.add(
+                                HoldingKey(
+                                    replacement.destination_batch_id,
+                                    current_holding.location_id,
+                                    current_holding.unit,
+                                    current_holding.packaging_configuration_id,
+                                )
+                            )
+            for prior_id, prior_holdings in touched:
+                overlap = holdings & prior_holdings
+                if overlap:
+                    raise ValueError(
+                        "events sharing occurred_at and effective_order touch the "
+                        f"same holding: {prior_id}, {_event_id(event)}"
+                    )
+            touched.append((_event_id(event), holdings))
 
     def _compile_observation(self, event: ObservationEvent) -> None:
         state = self._current.get(event.holding)
@@ -473,40 +740,50 @@ class _ProcessCompiler:
         elif state.domain != event.domain:
             raise ValueError("observation domain does not match holding state")
         _validate_observation(event.domain, event.observation)
-        observation = event.observation
-        if (
-            observation.lower is not None
-            and observation.lower == observation.upper
-        ):
-            self._system.add_constraint(
-                f"{event.event_id}:exact",
-                {state.variable_id: 1},
-                ConstraintRelation.EQUAL,
-                observation.lower,
-            )
-            return
-        if observation.lower is not None:
-            self._system.add_constraint(
-                f"{event.event_id}:lower",
-                {state.variable_id: 1},
-                ConstraintRelation.AT_LEAST,
-                observation.lower,
-            )
-        if observation.upper is not None:
-            self._system.add_constraint(
-                f"{event.event_id}:upper",
-                {state.variable_id: 1},
-                ConstraintRelation.AT_MOST,
-                observation.upper,
-            )
+        _add_observation_constraints(
+            self._system,
+            event.observation,
+            state.variable_id,
+            event.event_id,
+        )
 
-    def _compile_process(self, event: ProcessEvent) -> None:
+    def _compile_process(
+        self,
+        event: ProcessEvent,
+        resolved_candidates: dict[tuple[str, str], tuple[HoldingKey, ...]],
+    ) -> None:
+        if event.batch_replacements:
+            self._compile_batch_replacement(event, event.batch_replacements[0])
+            return
+        for output in event.outputs:
+            if isinstance(output.amount, FromInput):
+                candidates = resolved_candidates[
+                    (event.process_id, output.amount.input_id)
+                ]
+                if len(candidates) > 1:
+                    raise ValueError(
+                        "a resolved ambiguous input cannot become one concrete "
+                        "output Batch without allocation semantics"
+                    )
         input_variables: dict[str, str] = {}
         for process_input in event.inputs:
-            variable_id = self._compile_input(event, process_input)
+            variable_id = self._compile_input(
+                event,
+                process_input,
+                resolved_candidates[(event.process_id, process_input.input_id)],
+            )
             input_variables[process_input.input_id] = variable_id
+        source_variables = {
+            source.source_id: self._compile_source(event, source)
+            for source in event.sources
+        }
         for output in event.outputs:
-            self._compile_output(event, output, input_variables)
+            self._compile_output(
+                event,
+                output,
+                input_variables,
+                source_variables,
+            )
         for sink in event.sinks:
             self._compile_sink(event, sink, input_variables)
 
@@ -514,9 +791,10 @@ class _ProcessCompiler:
         self,
         event: ProcessEvent,
         process_input: ProcessInput,
+        candidates: tuple[HoldingKey, ...],
     ) -> str:
         before_states = []
-        for holding in process_input.candidates:
+        for holding in candidates:
             try:
                 before_states.append(self._current[holding])
             except KeyError as error:
@@ -619,9 +897,15 @@ class _ProcessCompiler:
         event: ProcessEvent,
         output: ProcessOutput,
         input_variables: dict[str, str],
+        source_variables: dict[str, str],
     ) -> None:
         if isinstance(output.amount, FromInput):
             flow_id = input_variables[output.amount.input_id]
+        elif isinstance(output.amount, FromSource):
+            flow_id = source_variables[output.amount.source_id]
+        else:
+            flow_id = ""
+        if isinstance(output.amount, (FromInput, FromSource)):
             variable = next(
                 variable
                 for variable in self._system.variables
@@ -661,6 +945,95 @@ class _ProcessCompiler:
             0,
         )
         self._current[output.holding] = after
+
+    def _compile_source(
+        self,
+        event: ProcessEvent,
+        source: ProcessSource,
+    ) -> str:
+        variable_id = f"source:{event.process_id}:{source.source_id}"
+        self._add_variable(
+            variable_id,
+            source.unit,
+            source.domain,
+            f"source[{event.process_id}.{source.source_id}:{source.kind}]",
+        )
+        self._source_variables[(event.process_id, source.source_id)] = variable_id
+        _add_observation_constraints(
+            self._system,
+            source.observation,
+            variable_id,
+            f"{event.process_id}:{source.source_id}",
+        )
+        return variable_id
+
+    def _compile_batch_replacement(
+        self,
+        event: ProcessEvent,
+        replacement: BatchReplacement,
+    ) -> None:
+        source_states = sorted(
+            (
+                state
+                for holding, state in self._current.items()
+                if holding.batch_id == replacement.source_batch_id
+            ),
+            key=lambda state: _holding_label(state.holding),
+        )
+        if not source_states:
+            raise ValueError("Batch replacement source has no earlier holding state")
+        mappings = []
+        for index, before in enumerate(source_states):
+            source_after = self._new_state(before.holding, before.domain)
+            flow_id = f"replacement:{event.process_id}:{index}"
+            self._add_variable(
+                flow_id,
+                before.holding.unit,
+                before.domain,
+                f"replacement[{event.process_id} <- {_holding_label(before.holding)}]",
+            )
+            self._system.add_constraint(
+                f"{event.process_id}:{replacement.replacement_id}:source:{index}",
+                {
+                    before.variable_id: 1,
+                    source_after.variable_id: -1,
+                    flow_id: -1,
+                },
+                ConstraintRelation.EQUAL,
+                0,
+            )
+            self._system.add_constraint(
+                f"{event.process_id}:{replacement.replacement_id}:all:{index}",
+                {source_after.variable_id: 1},
+                ConstraintRelation.EQUAL,
+                0,
+            )
+            self._current[before.holding] = source_after
+
+            destination = HoldingKey(
+                replacement.destination_batch_id,
+                before.holding.location_id,
+                before.holding.unit,
+                before.holding.packaging_configuration_id,
+            )
+            destination_before = self._current.get(destination)
+            destination_after = self._new_state(destination, before.domain)
+            coefficients = {destination_after.variable_id: 1, flow_id: -1}
+            if destination_before is not None:
+                if destination_before.domain != before.domain:
+                    raise ValueError(
+                        "Batch replacement destination has a different domain"
+                    )
+                coefficients[destination_before.variable_id] = -1
+            self._system.add_constraint(
+                f"{event.process_id}:{replacement.replacement_id}:destination:{index}",
+                coefficients,
+                ConstraintRelation.EQUAL,
+                0,
+            )
+            self._current[destination] = destination_after
+            mappings.append((before.holding, destination))
+        self._replacement_holdings[event.process_id] = tuple(mappings)
 
     def _compile_sink(
         self,
@@ -778,6 +1151,36 @@ def _validate_observation(
         ):
             if value is not None and value.denominator != 1:
                 raise ValueError("discrete observations must use whole amounts")
+
+
+def _add_observation_constraints(
+    system: QuantityConstraintSystem,
+    observation: QuantityObservation,
+    variable_id: str,
+    constraint_prefix: str,
+) -> None:
+    if observation.lower is not None and observation.lower == observation.upper:
+        system.add_constraint(
+            f"{constraint_prefix}:exact",
+            {variable_id: 1},
+            ConstraintRelation.EQUAL,
+            observation.lower,
+        )
+        return
+    if observation.lower is not None:
+        system.add_constraint(
+            f"{constraint_prefix}:lower",
+            {variable_id: 1},
+            ConstraintRelation.AT_LEAST,
+            observation.lower,
+        )
+    if observation.upper is not None:
+        system.add_constraint(
+            f"{constraint_prefix}:upper",
+            {variable_id: 1},
+            ConstraintRelation.AT_MOST,
+            observation.upper,
+        )
 
 
 def _validate_amount(

--- a/src/inventorius/process_quantities.py
+++ b/src/inventorius/process_quantities.py
@@ -198,6 +198,22 @@ class ProcessOutput:
 
 
 @dataclass(frozen=True)
+class PreservedIdentityOutput:
+    """Move each possible source Batch allocation to a new location."""
+
+    output_id: str
+    input_id: str
+    destination_location_id: str
+    role: str = "output"
+
+    def __post_init__(self) -> None:
+        _nonblank(self.output_id, "output_id")
+        _nonblank(self.input_id, "input_id")
+        _nonblank(self.destination_location_id, "destination_location_id")
+        _nonblank(self.role, "role")
+
+
+@dataclass(frozen=True)
 class ProcessSource:
     """A named external boundary admitting quantity into tracked holdings."""
 
@@ -266,6 +282,7 @@ class ProcessEvent:
     recorded_at: datetime
     inputs: tuple[ProcessInput, ...] = ()
     outputs: tuple[ProcessOutput, ...] = ()
+    preserved_outputs: tuple[PreservedIdentityOutput, ...] = ()
     sinks: tuple[ProcessSink, ...] = ()
     sources: tuple[ProcessSource, ...] = ()
     batch_replacements: tuple[BatchReplacement, ...] = ()
@@ -290,7 +307,11 @@ class ProcessEvent:
                 "output-only processes need explicit external-source semantics"
             )
         if self.batch_replacements and (
-            self.inputs or self.outputs or self.sinks or self.sources
+            self.inputs
+            or self.outputs
+            or self.preserved_outputs
+            or self.sinks
+            or self.sources
         ):
             raise ValueError(
                 "Batch replacement is an exclusive semantic process in this slice"
@@ -298,7 +319,9 @@ class ProcessEvent:
         if len(self.batch_replacements) > 1:
             raise ValueError("one process may replace only one Batch in this slice")
         input_ids = [item.input_id for item in self.inputs]
-        output_ids = [item.output_id for item in self.outputs]
+        output_ids = [item.output_id for item in self.outputs] + [
+            item.output_id for item in self.preserved_outputs
+        ]
         sink_ids = [item.sink_id for item in self.sinks]
         source_ids = [item.source_id for item in self.sources]
         if len(set(input_ids)) != len(input_ids):
@@ -310,6 +333,23 @@ class ProcessEvent:
         if len(set(source_ids)) != len(source_ids):
             raise ValueError("process source identifiers must be distinct")
         known_inputs = set(input_ids)
+        for output in self.preserved_outputs:
+            if output.input_id not in known_inputs:
+                raise ValueError("preserved output references an unknown input")
+            process_input = next(
+                item for item in self.inputs if item.input_id == output.input_id
+            )
+            if process_input.selector is None:
+                raise ValueError(
+                    "preserved candidate output needs an observed selection"
+                )
+            if any(
+                holding.location_id == output.destination_location_id
+                for holding in process_input.candidates
+            ):
+                raise ValueError(
+                    "preserved output destination must differ from its sources"
+                )
         for output in self.outputs:
             if (
                 isinstance(output.amount, FromInput)
@@ -347,6 +387,9 @@ class ProcessEvent:
             ) or any(
                 sink.amount.input_id == process_input.input_id
                 for sink in self.sinks
+            ) or any(
+                output.input_id == process_input.input_id
+                for output in self.preserved_outputs
             ) or bool(process_input.contributes_to)
             if not accounted:
                 raise ValueError(
@@ -367,7 +410,18 @@ class ProcessEvent:
         touched_inputs = [
             holding for item in self.inputs for holding in item.candidates
         ]
-        touched_outputs = [item.holding for item in self.outputs]
+        touched_outputs = [item.holding for item in self.outputs] + [
+            HoldingKey(
+                holding.batch_id,
+                output.destination_location_id,
+                holding.unit,
+                holding.packaging_configuration_id,
+            )
+            for output in self.preserved_outputs
+            for process_input in self.inputs
+            if process_input.input_id == output.input_id
+            for holding in process_input.candidates
+        ]
         if len(set(touched_inputs)) != len(touched_inputs):
             raise ValueError("one process cannot consume a holding twice")
         if len(set(touched_outputs)) != len(touched_outputs):
@@ -604,6 +658,9 @@ class _ProcessCompiler:
         self._allocation_variables: dict[
             tuple[str, str, HoldingKey], str
         ] = {}
+        self._input_candidate_variables: dict[
+            tuple[str, str, HoldingKey], str
+        ] = {}
         self._source_variables: dict[tuple[str, str], str] = {}
         self._replacement_holdings: dict[
             str, tuple[tuple[HoldingKey, HoldingKey], ...]
@@ -708,6 +765,14 @@ class _ProcessCompiler:
                     ]
                 }
                 holdings.update(output.holding for output in event.outputs)
+                for output in event.preserved_outputs:
+                    for source in resolved[(event.process_id, output.input_id)]:
+                        holdings.add(HoldingKey(
+                            source.batch_id,
+                            output.destination_location_id,
+                            source.unit,
+                            source.packaging_configuration_id,
+                        ))
                 for replacement in event.batch_replacements:
                     for current_holding in self._current:
                         if current_holding.batch_id in {
@@ -784,6 +849,12 @@ class _ProcessCompiler:
                 input_variables,
                 source_variables,
             )
+        for output in event.preserved_outputs:
+            self._compile_preserved_output(
+                event,
+                output,
+                resolved_candidates[(event.process_id, output.input_id)],
+            )
         for sink in event.sinks:
             self._compile_sink(event, sink, input_variables)
 
@@ -849,6 +920,9 @@ class _ProcessCompiler:
                     0,
                 )
             self._current[before.holding] = after
+            self._input_candidate_variables[
+                (event.process_id, process_input.input_id, before.holding)
+            ] = flow_id
             return flow_id
 
         allocation_ids = []
@@ -878,6 +952,9 @@ class _ProcessCompiler:
             )
             self._current[before.holding] = after
             self._allocation_variables[
+                (event.process_id, process_input.input_id, before.holding)
+            ] = allocation_id
+            self._input_candidate_variables[
                 (event.process_id, process_input.input_id, before.holding)
             ] = allocation_id
             allocation_ids.append(allocation_id)
@@ -945,6 +1022,40 @@ class _ProcessCompiler:
             0,
         )
         self._current[output.holding] = after
+
+    def _compile_preserved_output(
+        self,
+        event: ProcessEvent,
+        output: PreservedIdentityOutput,
+        candidates: tuple[HoldingKey, ...],
+    ) -> None:
+        for index, source in enumerate(candidates):
+            flow_id = self._input_candidate_variables[
+                (event.process_id, output.input_id, source)
+            ]
+            source_state = self._current[source]
+            destination = HoldingKey(
+                source.batch_id,
+                output.destination_location_id,
+                source.unit,
+                source.packaging_configuration_id,
+            )
+            before = self._current.get(destination)
+            after = self._new_state(destination, source_state.domain)
+            coefficients = {after.variable_id: 1, flow_id: -1}
+            if before is not None:
+                if before.domain != source_state.domain:
+                    raise ValueError(
+                        "preserved output domain differs from destination state"
+                    )
+                coefficients[before.variable_id] = -1
+            self._system.add_constraint(
+                f"{event.process_id}:{output.output_id}:destination:{index}",
+                coefficients,
+                ConstraintRelation.EQUAL,
+                0,
+            )
+            self._current[destination] = after
 
     def _compile_source(
         self,

--- a/src/inventorius/process_quantities.py
+++ b/src/inventorius/process_quantities.py
@@ -1,0 +1,823 @@
+"""Persistence-free process and observation compiler for quantity reasoning.
+
+This is the executable design seam that follows the rejected RC7
+``quantity-withdrawal`` product boundary.  Durable processes say what
+participated and what they produced.  The compiler creates temporary holding
+states, flow allocations, and linear constraints; source remainders are query
+results rather than process outputs or stored facts.
+
+The module deliberately has no Flask, MongoDB, codec, or authorization surface.
+It exists so the semantic model can be exercised before persistence makes it
+expensive to change.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime
+from fractions import Fraction
+from typing import Sequence
+
+from inventorius.ledger import HoldingKey
+from inventorius.quantity_constraints import (
+    BoundExplanation,
+    ConstraintRelation,
+    HoldingState,
+    LinearConstraint,
+    Number,
+    QuantityBounds,
+    QuantityConstraintSystem,
+    QuantityDomain,
+    QuantityObservation,
+    QuantityVariable,
+)
+
+
+def _nonblank(value: object, field: str) -> str:
+    if not isinstance(value, str) or not value.strip():
+        raise ValueError(f"{field} must be a nonblank string")
+    return value
+
+
+def _fraction(value: Number, field: str) -> Fraction:
+    if isinstance(value, bool):
+        raise ValueError(f"{field} must be an exact number")
+    if isinstance(value, Fraction):
+        result = value
+    elif isinstance(value, (int, str)):
+        try:
+            result = Fraction(value)
+        except (ValueError, ZeroDivisionError) as error:
+            raise ValueError(f"{field} must be an exact number") from error
+    else:
+        raise ValueError(f"{field} must be an int, decimal string, or Fraction")
+    return result
+
+
+def _aware(value: datetime, field: str) -> datetime:
+    if not isinstance(value, datetime) or value.tzinfo is None:
+        raise ValueError(f"{field} must be a timezone-aware datetime")
+    return value
+
+
+@dataclass(frozen=True, init=False)
+class ExactAmount:
+    """One positive exact amount participating in a process flow."""
+
+    amount: Fraction
+
+    def __init__(self, amount: Number):
+        value = _fraction(amount, "amount")
+        if value <= 0:
+            raise ValueError("amount must be positive")
+        object.__setattr__(self, "amount", value)
+
+
+@dataclass(frozen=True)
+class AllRemaining:
+    """Consume the complete quantity then feasible in one holding."""
+
+
+ALL_REMAINING = AllRemaining()
+
+
+@dataclass(frozen=True)
+class FromInput:
+    """Produce exactly the amount compiled for one process input."""
+
+    input_id: str
+
+    def __post_init__(self) -> None:
+        _nonblank(self.input_id, "input_id")
+
+
+InputAmount = ExactAmount | AllRemaining
+OutputAmount = ExactAmount | FromInput
+
+
+@dataclass(frozen=True)
+class ProcessInput:
+    """A quantity consumed from one holding or an unresolved candidate set."""
+
+    input_id: str
+    candidates: tuple[HoldingKey, ...]
+    amount: InputAmount
+    role: str = "input"
+    selector: str | None = None
+    contributes_to: tuple[str, ...] = ()
+
+    def __post_init__(self) -> None:
+        _nonblank(self.input_id, "input_id")
+        _nonblank(self.role, "role")
+        if not self.candidates:
+            raise ValueError("a process input needs at least one candidate holding")
+        if len(set(self.candidates)) != len(self.candidates):
+            raise ValueError("process input candidates must be distinct")
+        if not isinstance(self.amount, (ExactAmount, AllRemaining)):
+            raise ValueError("process input amount has an unsupported type")
+        if isinstance(self.amount, AllRemaining) and len(self.candidates) != 1:
+            raise ValueError("all remaining requires one exact holding")
+        if len(self.candidates) > 1:
+            _nonblank(self.selector, "selector")
+        elif self.selector is not None:
+            _nonblank(self.selector, "selector")
+        if len(set(self.contributes_to)) != len(self.contributes_to):
+            raise ValueError("contributes_to output identifiers must be distinct")
+        for output_id in self.contributes_to:
+            _nonblank(output_id, "contributes_to output identifier")
+
+
+@dataclass(frozen=True)
+class ProcessOutput:
+    """A quantity produced into one concrete holding."""
+
+    output_id: str
+    holding: HoldingKey
+    domain: QuantityDomain
+    amount: OutputAmount
+    role: str = "output"
+
+    def __post_init__(self) -> None:
+        _nonblank(self.output_id, "output_id")
+        _nonblank(self.role, "role")
+        if not isinstance(self.holding, HoldingKey):
+            raise ValueError("process output holding must be a HoldingKey")
+        if not isinstance(self.domain, QuantityDomain):
+            raise ValueError("process output domain must be a QuantityDomain")
+        if not isinstance(self.amount, (ExactAmount, FromInput)):
+            raise ValueError("process output amount has an unsupported type")
+
+
+@dataclass(frozen=True)
+class ProcessSink:
+    """An explicit external destination for one compiled input quantity."""
+
+    sink_id: str
+    kind: str
+    unit: str
+    domain: QuantityDomain
+    amount: FromInput
+    note: str = ""
+
+    def __post_init__(self) -> None:
+        _nonblank(self.sink_id, "sink_id")
+        _nonblank(self.kind, "kind")
+        _nonblank(self.unit, "unit")
+        if not isinstance(self.domain, QuantityDomain):
+            raise ValueError("process sink domain must be a QuantityDomain")
+        if not isinstance(self.amount, FromInput):
+            raise ValueError("process sink must reference one process input")
+
+
+@dataclass(frozen=True)
+class ProcessEvent:
+    """One physical or identity-changing process known to Inventorius."""
+
+    process_id: str
+    kind: str
+    occurred_at: datetime
+    recorded_at: datetime
+    inputs: tuple[ProcessInput, ...] = ()
+    outputs: tuple[ProcessOutput, ...] = ()
+    sinks: tuple[ProcessSink, ...] = ()
+    note: str = ""
+
+    def __post_init__(self) -> None:
+        _nonblank(self.process_id, "process_id")
+        _nonblank(self.kind, "kind")
+        occurred = _aware(self.occurred_at, "occurred_at")
+        recorded = _aware(self.recorded_at, "recorded_at")
+        if recorded < occurred:
+            raise ValueError("recorded_at cannot precede occurred_at")
+        if not self.inputs:
+            raise ValueError(
+                "output-only processes need explicit external-source semantics"
+            )
+        input_ids = [item.input_id for item in self.inputs]
+        output_ids = [item.output_id for item in self.outputs]
+        sink_ids = [item.sink_id for item in self.sinks]
+        if len(set(input_ids)) != len(input_ids):
+            raise ValueError("process input identifiers must be distinct")
+        if len(set(output_ids)) != len(output_ids):
+            raise ValueError("process output identifiers must be distinct")
+        if len(set(sink_ids)) != len(sink_ids):
+            raise ValueError("process sink identifiers must be distinct")
+        known_inputs = set(input_ids)
+        for output in self.outputs:
+            if (
+                isinstance(output.amount, FromInput)
+                and output.amount.input_id not in known_inputs
+            ):
+                raise ValueError("process output references an unknown input")
+            if isinstance(output.amount, FromInput):
+                source = next(
+                    item
+                    for item in self.inputs
+                    if item.input_id == output.amount.input_id
+                )
+                if len(source.candidates) > 1:
+                    raise ValueError(
+                        "an ambiguous input cannot become one concrete output "
+                        "Batch without allocation semantics"
+                    )
+        for sink in self.sinks:
+            if sink.amount.input_id not in known_inputs:
+                raise ValueError("process sink references an unknown input")
+        known_outputs = set(output_ids)
+        for process_input in self.inputs:
+            unknown = set(process_input.contributes_to) - known_outputs
+            if unknown:
+                raise ValueError("process input contributes to an unknown output")
+            accounted = any(
+                isinstance(output.amount, FromInput)
+                and output.amount.input_id == process_input.input_id
+                for output in self.outputs
+            ) or any(
+                sink.amount.input_id == process_input.input_id
+                for sink in self.sinks
+            ) or bool(process_input.contributes_to)
+            if not accounted:
+                raise ValueError(
+                    "every process input needs an output, sink, or structural "
+                    "contribution"
+                )
+        touched_inputs = [
+            holding for item in self.inputs for holding in item.candidates
+        ]
+        touched_outputs = [item.holding for item in self.outputs]
+        if len(set(touched_inputs)) != len(touched_inputs):
+            raise ValueError("one process cannot consume a holding twice")
+        if len(set(touched_outputs)) != len(touched_outputs):
+            raise ValueError("one process cannot produce into a holding twice")
+        if set(touched_inputs) & set(touched_outputs):
+            raise ValueError(
+                "same-holding input/output semantics are not defined yet"
+            )
+
+
+@dataclass(frozen=True)
+class ObservationEvent:
+    """A non-consuming claim about one holding at one occurrence time."""
+
+    holding: HoldingKey
+    domain: QuantityDomain
+    observation: QuantityObservation
+    occurred_at: datetime
+    recorded_at: datetime
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.holding, HoldingKey):
+            raise ValueError("observation holding must be a HoldingKey")
+        if not isinstance(self.domain, QuantityDomain):
+            raise ValueError("observation domain must be a QuantityDomain")
+        if not isinstance(self.observation, QuantityObservation):
+            raise ValueError("observation must be a QuantityObservation")
+        occurred = _aware(self.occurred_at, "occurred_at")
+        recorded = _aware(self.recorded_at, "recorded_at")
+        if recorded < occurred:
+            raise ValueError("recorded_at cannot precede occurred_at")
+
+    @property
+    def event_id(self) -> str:
+        return self.observation.observation_id
+
+
+QuantityEvent = ProcessEvent | ObservationEvent
+
+
+class ProcessQuantityTimeline:
+    """Append recorded events and recompile physical history when queried."""
+
+    def __init__(self, *, query_timeout_ms: int = 5_000) -> None:
+        self._query_timeout_ms = query_timeout_ms
+        self._events: list[QuantityEvent] = []
+        self._event_ids: set[str] = set()
+
+    @property
+    def events(self) -> tuple[QuantityEvent, ...]:
+        return tuple(self._events)
+
+    def record(self, event: QuantityEvent) -> None:
+        if not isinstance(event, (ProcessEvent, ObservationEvent)):
+            raise ValueError("event must be a process or observation")
+        event_id = _event_id(event)
+        if event_id in self._event_ids:
+            raise ValueError(f"duplicate quantity event: {event_id}")
+        self._events.append(event)
+        self._event_ids.add(event_id)
+
+    def compile(
+        self,
+        *,
+        known_at: datetime | None = None,
+    ) -> CompiledProcessQuantities:
+        if known_at is not None:
+            _aware(known_at, "known_at")
+        events = [
+            event
+            for event in self._events
+            if known_at is None or event.recorded_at <= known_at
+        ]
+        events.sort(
+            key=lambda event: (
+                event.occurred_at,
+                event.recorded_at,
+                _event_id(event),
+            )
+        )
+        return _ProcessCompiler(self._query_timeout_ms).compile(events)
+
+
+class CompiledProcessQuantities:
+    """One disposable solver projection of the recorded process timeline."""
+
+    def __init__(
+        self,
+        system: QuantityConstraintSystem,
+        current: dict[HoldingKey, HoldingState],
+        input_variables: dict[tuple[str, str], str],
+        allocation_variables: dict[tuple[str, str, HoldingKey], str],
+        labels: dict[str, str],
+        event_order: tuple[str, ...],
+    ) -> None:
+        self._system = system
+        self._current = current
+        self._input_variables = input_variables
+        self._allocation_variables = allocation_variables
+        self._labels = labels
+        self._event_order = event_order
+
+    @property
+    def constraints(self) -> tuple[LinearConstraint, ...]:
+        return self._system.constraints
+
+    @property
+    def event_order(self) -> tuple[str, ...]:
+        return self._event_order
+
+    @property
+    def holdings(self) -> tuple[HoldingKey, ...]:
+        return tuple(self._current)
+
+    def is_feasible(self) -> bool:
+        return self._system.is_feasible()
+
+    def conflict(self) -> tuple[str, ...]:
+        return self._system.conflict()
+
+    def current_bounds(self, holding: HoldingKey) -> QuantityBounds:
+        try:
+            state = self._current[holding]
+        except KeyError as error:
+            raise ValueError("holding has no compiled quantity state") from error
+        return self._system.bounds(state.variable_id)
+
+    def explain_current(self, holding: HoldingKey) -> BoundExplanation:
+        try:
+            state = self._current[holding]
+        except KeyError as error:
+            raise ValueError("holding has no compiled quantity state") from error
+        return self._system.explain_bounds(state.variable_id)
+
+    def current_total_bounds(
+        self,
+        holdings: Sequence[HoldingKey],
+    ) -> QuantityBounds:
+        selected = tuple(holdings)
+        if not selected:
+            raise ValueError("a current total needs at least one holding")
+        if len(set(selected)) != len(selected):
+            raise ValueError("a current total needs distinct holdings")
+        states = []
+        for holding in selected:
+            try:
+                states.append(self._current[holding])
+            except KeyError as error:
+                raise ValueError(
+                    "holding has no compiled quantity state"
+                ) from error
+        _require_compatible(states, "current total", require_batch=False)
+        return self._system.expression_bounds(
+            {state.variable_id: 1 for state in states}
+        )
+
+    def input_bounds(self, process_id: str, input_id: str) -> QuantityBounds:
+        try:
+            variable_id = self._input_variables[(process_id, input_id)]
+        except KeyError as error:
+            raise ValueError("process input has no compiled quantity") from error
+        return self._system.bounds(variable_id)
+
+    def allocation_bounds(
+        self,
+        process_id: str,
+        input_id: str,
+        holding: HoldingKey,
+    ) -> QuantityBounds:
+        try:
+            variable_id = self._allocation_variables[
+                (process_id, input_id, holding)
+            ]
+        except KeyError as error:
+            raise ValueError(
+                "process input has no allocation for that holding"
+            ) from error
+        return self._system.bounds(variable_id)
+
+    def rendered_constraints(self) -> tuple[str, ...]:
+        """Return readable algebra without exposing generated Z3 expressions."""
+
+        return tuple(
+            _render_constraint(constraint, self._labels)
+            for constraint in self._system.constraints
+            if not constraint.constraint_id.startswith("domain:")
+        )
+
+
+class _ProcessCompiler:
+    def __init__(self, timeout_ms: int) -> None:
+        self._system = QuantityConstraintSystem(timeout_ms=timeout_ms)
+        self._current: dict[HoldingKey, HoldingState] = {}
+        self._revisions: dict[HoldingKey, int] = {}
+        self._input_variables: dict[tuple[str, str], str] = {}
+        self._allocation_variables: dict[
+            tuple[str, str, HoldingKey], str
+        ] = {}
+        self._labels: dict[str, str] = {}
+
+    def compile(
+        self,
+        events: Sequence[QuantityEvent],
+    ) -> CompiledProcessQuantities:
+        order = []
+        for event in events:
+            order.append(_event_id(event))
+            if isinstance(event, ObservationEvent):
+                self._compile_observation(event)
+            else:
+                self._compile_process(event)
+        return CompiledProcessQuantities(
+            self._system,
+            dict(self._current),
+            dict(self._input_variables),
+            dict(self._allocation_variables),
+            dict(self._labels),
+            tuple(order),
+        )
+
+    def _compile_observation(self, event: ObservationEvent) -> None:
+        state = self._current.get(event.holding)
+        if state is None:
+            state = self._new_state(event.holding, event.domain)
+            self._current[event.holding] = state
+        elif state.domain != event.domain:
+            raise ValueError("observation domain does not match holding state")
+        _validate_observation(event.domain, event.observation)
+        observation = event.observation
+        if (
+            observation.lower is not None
+            and observation.lower == observation.upper
+        ):
+            self._system.add_constraint(
+                f"{event.event_id}:exact",
+                {state.variable_id: 1},
+                ConstraintRelation.EQUAL,
+                observation.lower,
+            )
+            return
+        if observation.lower is not None:
+            self._system.add_constraint(
+                f"{event.event_id}:lower",
+                {state.variable_id: 1},
+                ConstraintRelation.AT_LEAST,
+                observation.lower,
+            )
+        if observation.upper is not None:
+            self._system.add_constraint(
+                f"{event.event_id}:upper",
+                {state.variable_id: 1},
+                ConstraintRelation.AT_MOST,
+                observation.upper,
+            )
+
+    def _compile_process(self, event: ProcessEvent) -> None:
+        input_variables: dict[str, str] = {}
+        for process_input in event.inputs:
+            variable_id = self._compile_input(event, process_input)
+            input_variables[process_input.input_id] = variable_id
+        for output in event.outputs:
+            self._compile_output(event, output, input_variables)
+        for sink in event.sinks:
+            self._compile_sink(event, sink, input_variables)
+
+    def _compile_input(
+        self,
+        event: ProcessEvent,
+        process_input: ProcessInput,
+    ) -> str:
+        before_states = []
+        for holding in process_input.candidates:
+            try:
+                before_states.append(self._current[holding])
+            except KeyError as error:
+                raise ValueError(
+                    f"process input holding has no earlier state: {holding}"
+                ) from error
+        _require_compatible(
+            before_states,
+            "process input candidates",
+            require_batch=False,
+        )
+        domain = before_states[0].domain
+        unit = before_states[0].holding.unit
+        flow_id = f"flow:{event.process_id}:{process_input.input_id}"
+        self._add_variable(
+            flow_id,
+            unit,
+            domain,
+            f"flow[{event.process_id}.{process_input.input_id}]",
+        )
+        self._input_variables[
+            (event.process_id, process_input.input_id)
+        ] = flow_id
+
+        if isinstance(process_input.amount, ExactAmount):
+            _validate_amount(domain, process_input.amount.amount, "input amount")
+            self._system.add_constraint(
+                f"{event.process_id}:{process_input.input_id}:amount",
+                {flow_id: 1},
+                ConstraintRelation.EQUAL,
+                process_input.amount.amount,
+            )
+
+        if len(before_states) == 1:
+            before = before_states[0]
+            after = self._new_state(before.holding, before.domain)
+            self._system.add_constraint(
+                f"{event.process_id}:{process_input.input_id}:source",
+                {
+                    before.variable_id: 1,
+                    after.variable_id: -1,
+                    flow_id: -1,
+                },
+                ConstraintRelation.EQUAL,
+                0,
+            )
+            if isinstance(process_input.amount, AllRemaining):
+                self._system.add_constraint(
+                    f"{event.process_id}:{process_input.input_id}:all",
+                    {after.variable_id: 1},
+                    ConstraintRelation.EQUAL,
+                    0,
+                )
+            self._current[before.holding] = after
+            return flow_id
+
+        allocation_ids = []
+        for index, before in enumerate(before_states):
+            allocation_id = (
+                f"allocation:{event.process_id}:{process_input.input_id}:{index}"
+            )
+            self._add_variable(
+                allocation_id,
+                unit,
+                domain,
+                (
+                    f"allocation[{event.process_id}.{process_input.input_id}"
+                    f" <- {_holding_label(before.holding)}]"
+                ),
+            )
+            after = self._new_state(before.holding, before.domain)
+            self._system.add_constraint(
+                f"{event.process_id}:{process_input.input_id}:source:{index}",
+                {
+                    before.variable_id: 1,
+                    after.variable_id: -1,
+                    allocation_id: -1,
+                },
+                ConstraintRelation.EQUAL,
+                0,
+            )
+            self._current[before.holding] = after
+            self._allocation_variables[
+                (event.process_id, process_input.input_id, before.holding)
+            ] = allocation_id
+            allocation_ids.append(allocation_id)
+        self._system.add_constraint(
+            f"{event.process_id}:{process_input.input_id}:allocation-total",
+            {
+                **{allocation_id: 1 for allocation_id in allocation_ids},
+                flow_id: -1,
+            },
+            ConstraintRelation.EQUAL,
+            0,
+        )
+        return flow_id
+
+    def _compile_output(
+        self,
+        event: ProcessEvent,
+        output: ProcessOutput,
+        input_variables: dict[str, str],
+    ) -> None:
+        if isinstance(output.amount, FromInput):
+            flow_id = input_variables[output.amount.input_id]
+            variable = next(
+                variable
+                for variable in self._system.variables
+                if variable.variable_id == flow_id
+            )
+            if variable.unit != output.holding.unit:
+                raise ValueError("linked process input/output units differ")
+            if variable.domain != output.domain:
+                raise ValueError("linked process input/output domains differ")
+        else:
+            _validate_amount(output.domain, output.amount.amount, "output amount")
+            flow_id = f"output:{event.process_id}:{output.output_id}"
+            self._add_variable(
+                flow_id,
+                output.holding.unit,
+                output.domain,
+                f"output[{event.process_id}.{output.output_id}]",
+            )
+            self._system.add_constraint(
+                f"{event.process_id}:{output.output_id}:amount",
+                {flow_id: 1},
+                ConstraintRelation.EQUAL,
+                output.amount.amount,
+            )
+
+        before = self._current.get(output.holding)
+        after = self._new_state(output.holding, output.domain)
+        coefficients = {after.variable_id: 1, flow_id: -1}
+        if before is not None:
+            if before.domain != output.domain:
+                raise ValueError("process output domain differs from holding state")
+            coefficients[before.variable_id] = -1
+        self._system.add_constraint(
+            f"{event.process_id}:{output.output_id}:destination",
+            coefficients,
+            ConstraintRelation.EQUAL,
+            0,
+        )
+        self._current[output.holding] = after
+
+    def _compile_sink(
+        self,
+        event: ProcessEvent,
+        sink: ProcessSink,
+        input_variables: dict[str, str],
+    ) -> None:
+        input_variable_id = input_variables[sink.amount.input_id]
+        input_variable = next(
+            variable
+            for variable in self._system.variables
+            if variable.variable_id == input_variable_id
+        )
+        if input_variable.unit != sink.unit:
+            raise ValueError("linked process input/sink units differ")
+        if input_variable.domain != sink.domain:
+            raise ValueError("linked process input/sink domains differ")
+        sink_variable_id = f"sink:{event.process_id}:{sink.sink_id}"
+        self._add_variable(
+            sink_variable_id,
+            sink.unit,
+            sink.domain,
+            f"sink[{event.process_id}.{sink.sink_id}:{sink.kind}]",
+        )
+        self._system.add_constraint(
+            f"{event.process_id}:{sink.sink_id}:sink",
+            {sink_variable_id: 1, input_variable_id: -1},
+            ConstraintRelation.EQUAL,
+            0,
+        )
+
+    def _new_state(
+        self,
+        holding: HoldingKey,
+        domain: QuantityDomain,
+    ) -> HoldingState:
+        revision = self._revisions.get(holding, -1) + 1
+        self._revisions[holding] = revision
+        variable_id = (
+            f"state:{holding.batch_id}:{holding.location_id}:"
+            f"{holding.unit}:{holding.packaging_configuration_id or '-'}:r{revision}"
+        )
+        self._add_variable(
+            variable_id,
+            holding.unit,
+            domain,
+            f"state[{_holding_label(holding)} #{revision}]",
+        )
+        return HoldingState(holding, domain, revision, variable_id)
+
+    def _add_variable(
+        self,
+        variable_id: str,
+        unit: str,
+        domain: QuantityDomain,
+        label: str,
+    ) -> None:
+        self._system.add_variable(QuantityVariable(variable_id, unit, domain))
+        self._labels[variable_id] = label
+
+
+def _event_id(event: QuantityEvent) -> str:
+    if isinstance(event, ProcessEvent):
+        return event.process_id
+    return event.event_id
+
+
+def _holding_label(holding: HoldingKey) -> str:
+    label = f"{holding.batch_id} @ {holding.location_id}"
+    if holding.packaging_configuration_id is not None:
+        label += f" / {holding.packaging_configuration_id}"
+    return label
+
+
+def _require_compatible(
+    states: Sequence[HoldingState],
+    subject: str,
+    *,
+    require_batch: bool,
+) -> None:
+    if not states:
+        raise ValueError(f"{subject} needs at least one state")
+    first = states[0]
+    signature = (
+        first.holding.unit,
+        first.holding.packaging_configuration_id,
+        first.domain,
+    )
+    if require_batch:
+        signature = (first.holding.batch_id, *signature)
+    for state in states[1:]:
+        candidate = (
+            state.holding.unit,
+            state.holding.packaging_configuration_id,
+            state.domain,
+        )
+        if require_batch:
+            candidate = (state.holding.batch_id, *candidate)
+        if candidate != signature:
+            raise ValueError(
+                f"{subject} must use compatible units, package configurations, "
+                "and numeric domains"
+            )
+
+
+def _validate_observation(
+    domain: QuantityDomain,
+    observation: QuantityObservation,
+) -> None:
+    if domain == QuantityDomain.DISCRETE:
+        for value in (
+            observation.lower,
+            observation.preferred,
+            observation.upper,
+        ):
+            if value is not None and value.denominator != 1:
+                raise ValueError("discrete observations must use whole amounts")
+
+
+def _validate_amount(
+    domain: QuantityDomain,
+    amount: Fraction,
+    field: str,
+) -> None:
+    if amount <= 0:
+        raise ValueError(f"{field} must be positive")
+    if domain == QuantityDomain.DISCRETE and amount.denominator != 1:
+        raise ValueError(f"discrete {field} must be a whole amount")
+
+
+def _render_fraction(value: Fraction) -> str:
+    if value.denominator == 1:
+        return str(value.numerator)
+    return f"{value.numerator}/{value.denominator}"
+
+
+def _render_constraint(
+    constraint: LinearConstraint,
+    labels: dict[str, str],
+) -> str:
+    terms = []
+    for variable_id, coefficient in constraint.coefficients:
+        label = labels.get(variable_id, variable_id)
+        magnitude = abs(coefficient)
+        rendered = label
+        if magnitude != 1:
+            rendered = f"{_render_fraction(magnitude)}*{rendered}"
+        if not terms:
+            terms.append(f"-{rendered}" if coefficient < 0 else rendered)
+        else:
+            terms.append(f" {'-' if coefficient < 0 else '+'} {rendered}")
+    relation = {
+        ConstraintRelation.EQUAL: "=",
+        ConstraintRelation.AT_LEAST: ">=",
+        ConstraintRelation.AT_MOST: "<=",
+    }[constraint.relation]
+    return (
+        f"{constraint.constraint_id}: {''.join(terms)} {relation} "
+        f"{_render_fraction(constraint.bound)}"
+    )

--- a/tests/test_process_quantities.py
+++ b/tests/test_process_quantities.py
@@ -7,15 +7,18 @@ import pytest
 
 from inventorius.ledger import HoldingKey
 from inventorius.process_quantities import (
-    ALL_REMAINING,
+    BatchReplacement,
+    CandidateSelection,
     ExactAmount,
     FromInput,
+    FromSource,
     ObservationEvent,
     ProcessEvent,
     ProcessInput,
     ProcessOutput,
     ProcessQuantityTimeline,
     ProcessSink,
+    ProcessSource,
 )
 from inventorius.quantity_constraints import (
     InfeasibleQuantityFacts,
@@ -73,6 +76,21 @@ def assert_bounds(bounds, minimum, maximum):
     assert bounds.minimum == (
         None if minimum is None else Fraction(str(minimum))
     )
+
+
+def selection(
+    selection_id: str,
+    sku_id: str,
+    location_id: str,
+    *candidates: HoldingKey,
+) -> CandidateSelection:
+    return CandidateSelection(
+        selection_id,
+        sku_id,
+        location_id,
+        candidates[0].unit,
+        candidates[0].packaging_configuration_id,
+    )
     assert bounds.maximum == (
         None if maximum is None else Fraction(str(maximum))
     )
@@ -122,7 +140,13 @@ def test_same_sku_same_bin_preserves_unknown_batch_allocation():
             "fasteners",
             (first, second),
             ExactAmount(5),
-            selector="SKU-FASTENER observed in BIN-SHARED",
+            selector=selection(
+                "SEL-fasteners",
+                "SKU-FASTENER",
+                "BIN-SHARED",
+                first,
+                second,
+            ),
         ),),
         sinks=(ProcessSink(
             "project",
@@ -184,15 +208,17 @@ def test_audit_constraints_can_assert_lower_upper_or_complete_count():
     assert_bounds(exact.current_bounds(holding), 25, 25)
 
 
-def test_whole_batch_reclassification_consumes_identity_not_a_remainder():
-    old = HoldingKey("BAT-WRONG", "BIN-PARTS", "each")
-    new = HoldingKey("BAT-CORRECT", "BIN-PARTS", "each")
+def test_whole_batch_reclassification_expands_across_every_current_holding():
+    old_first = HoldingKey("BAT-WRONG", "BIN-PARTS", "each")
+    old_second = HoldingKey("BAT-WRONG", "BENCH", "each")
+    new_first = HoldingKey("BAT-CORRECT", "BIN-PARTS", "each")
+    new_second = HoldingKey("BAT-CORRECT", "BENCH", "each")
     timeline = ProcessQuantityTimeline()
     timeline.record(observation(
-        "OBS-old-estimate",
-        old,
+        "OBS-old-first-estimate",
+        old_first,
         QuantityObservation(
-            "OBS-old-estimate",
+            "OBS-old-first-estimate",
             lower=8,
             preferred=10,
             upper=12,
@@ -200,25 +226,74 @@ def test_whole_batch_reclassification_consumes_identity_not_a_remainder():
         ),
         1,
     ))
+    timeline.record(exact_observation(
+        "OBS-old-second-three",
+        old_second,
+        3,
+        1,
+    ))
     timeline.record(ProcessEvent(
         "PROC-reclassify",
         "reclassify",
         moment(2),
         moment(2),
-        inputs=(ProcessInput("old-batch", (old,), ALL_REMAINING),),
-        outputs=(ProcessOutput(
-            "new-batch",
-            new,
-            DISCRETE,
-            FromInput("old-batch"),
+        batch_replacements=(BatchReplacement(
+            "replace-identity",
+            "BAT-WRONG",
+            "BAT-CORRECT",
         ),),
     ))
 
     compiled = timeline.compile()
 
-    assert_bounds(compiled.current_bounds(old), 0, 0)
-    assert_bounds(compiled.current_bounds(new), 8, 12)
-    assert_bounds(compiled.input_bounds("PROC-reclassify", "old-batch"), 8, 12)
+    assert_bounds(compiled.current_bounds(old_first), 0, 0)
+    assert_bounds(compiled.current_bounds(old_second), 0, 0)
+    assert_bounds(compiled.current_bounds(new_first), 8, 12)
+    assert_bounds(compiled.current_bounds(new_second), 3, 3)
+    assert compiled.replacement_holdings("PROC-reclassify") == (
+        (old_second, new_second),
+        (old_first, new_first),
+    )
+
+
+def test_late_discovered_holding_joins_batch_replacement_on_current_replay():
+    known = HoldingKey("BAT-WRONG", "BIN-A", "each")
+    discovered_late = HoldingKey("BAT-WRONG", "BIN-B", "each")
+    corrected_known = HoldingKey("BAT-CORRECT", "BIN-A", "each")
+    corrected_late = HoldingKey("BAT-CORRECT", "BIN-B", "each")
+    timeline = ProcessQuantityTimeline()
+    timeline.record(exact_observation("OBS-known", known, 2, 1))
+    timeline.record(exact_observation(
+        "OBS-discovered-late",
+        discovered_late,
+        4,
+        1,
+        recorded_day=3,
+    ))
+    timeline.record(ProcessEvent(
+        "PROC-reclassify",
+        "reclassify",
+        moment(2),
+        moment(2),
+        batch_replacements=(BatchReplacement(
+            "replace-identity",
+            "BAT-WRONG",
+            "BAT-CORRECT",
+        ),),
+    ))
+
+    historical = timeline.compile(known_at=moment(2, 13))
+    assert historical.replacement_holdings("PROC-reclassify") == (
+        (known, corrected_known),
+    )
+
+    current = timeline.compile()
+    assert current.replacement_holdings("PROC-reclassify") == (
+        (known, corrected_known),
+        (discovered_late, corrected_late),
+    )
+    assert_bounds(current.current_bounds(discovered_late), 0, 0)
+    assert_bounds(current.current_bounds(corrected_late), 4, 4)
 
 
 def test_assembly_is_a_normal_process_without_adding_incompatible_units():
@@ -365,6 +440,148 @@ def test_output_only_process_waits_for_explicit_external_source_semantics():
         )
 
 
+def test_receive_uses_an_explicit_bounded_external_source():
+    holding = HoldingKey("BAT-LIQUID", "SHELF", "milliliter")
+    timeline = ProcessQuantityTimeline()
+    timeline.record(ProcessEvent(
+        "PROC-receive-liquid",
+        "receive",
+        moment(1),
+        moment(1),
+        sources=(ProcessSource(
+            "supplier-bottle",
+            "supplier shipment",
+            "milliliter",
+            QuantityDomain.CONTINUOUS,
+            QuantityObservation.estimated("OBS-bottle-estimate", 50),
+        ),),
+        outputs=(ProcessOutput(
+            "received-bottle",
+            holding,
+            QuantityDomain.CONTINUOUS,
+            FromSource("supplier-bottle"),
+        ),),
+    ))
+
+    compiled = timeline.compile()
+
+    assert_bounds(compiled.source_bounds(
+        "PROC-receive-liquid",
+        "supplier-bottle",
+    ), 0, 100)
+    assert_bounds(compiled.current_bounds(holding), 0, 100)
+
+
+def test_equal_time_overlap_requires_explicit_effective_order():
+    source = HoldingKey("BAT-X", "BIN-A", "each")
+    destination = HoldingKey("BAT-X", "BIN-B", "each")
+    timeline = ProcessQuantityTimeline()
+    timeline.record(exact_observation("OBS-opening", source, 3, 1))
+    timeline.record(ProcessEvent(
+        "PROC-move-one",
+        "move",
+        moment(1),
+        moment(1),
+        inputs=(ProcessInput("moved", (source,), ExactAmount(1)),),
+        outputs=(ProcessOutput(
+            "destination",
+            destination,
+            DISCRETE,
+            FromInput("moved"),
+        ),),
+    ))
+
+    with pytest.raises(ValueError, match="effective_order"):
+        timeline.compile()
+
+    ordered = ProcessQuantityTimeline()
+    ordered.record(exact_observation("OBS-opening", source, 3, 1))
+    ordered.record(ProcessEvent(
+        "PROC-move-one",
+        "move",
+        moment(1),
+        moment(1),
+        inputs=(ProcessInput("moved", (source,), ExactAmount(1)),),
+        outputs=(ProcessOutput(
+            "destination",
+            destination,
+            DISCRETE,
+            FromInput("moved"),
+        ),),
+        effective_order=1,
+    ))
+    compiled = ordered.compile()
+    assert_bounds(compiled.current_bounds(source), 2, 2)
+    assert_bounds(compiled.current_bounds(destination), 1, 1)
+
+
+def test_ambiguous_selection_can_gain_a_late_discovered_candidate():
+    first = HoldingKey("BAT-A", "BIN-SHARED", "each")
+    second = HoldingKey("BAT-B", "BIN-SHARED", "each")
+    late = HoldingKey("BAT-C", "BIN-SHARED", "each")
+    selector = selection(
+        "SEL-shared-fasteners",
+        "SKU-FASTENER",
+        "BIN-SHARED",
+        first,
+        second,
+    )
+    timeline = ProcessQuantityTimeline()
+    timeline.record(exact_observation("OBS-A-two", first, 2, 1))
+    timeline.record(exact_observation("OBS-B-two", second, 2, 1))
+    timeline.record(exact_observation("OBS-C-two-late", late, 2, 1, 3))
+    timeline.record(ProcessEvent(
+        "PROC-take-three",
+        "consume",
+        moment(2),
+        moment(2),
+        inputs=(ProcessInput(
+            "fasteners",
+            (first, second),
+            ExactAmount(3),
+            selector=selector,
+        ),),
+        sinks=(ProcessSink(
+            "project",
+            "consumed by project",
+            "each",
+            DISCRETE,
+            FromInput("fasteners"),
+        ),),
+    ))
+
+    def resolve(
+        candidate_selection,
+        candidates_at_recording,
+        occurred_at,
+        known_at,
+    ):
+        assert candidate_selection == selector
+        assert candidates_at_recording == (first, second)
+        assert occurred_at == moment(2)
+        return (first, second, late) if known_at is None else (first, second)
+
+    historical = timeline.compile(
+        known_at=moment(2, 13),
+        candidate_resolver=resolve,
+    )
+    assert_bounds(historical.current_total_bounds((first, second)), 1, 1)
+    with pytest.raises(ValueError, match="no allocation"):
+        historical.allocation_bounds(
+            "PROC-take-three",
+            "fasteners",
+            late,
+        )
+
+    current = timeline.compile(candidate_resolver=resolve)
+    assert_bounds(current.current_total_bounds((first, second, late)), 3, 3)
+    assert_bounds(current.allocation_bounds(
+        "PROC-take-three",
+        "fasteners",
+        late,
+    ), 0, 2)
+
+
 def test_ambiguous_input_cannot_collapse_into_one_concrete_batch():
     first = HoldingKey("BAT-A", "BIN-A", "each")
     second = HoldingKey("BAT-B", "BIN-A", "each")
@@ -379,7 +596,13 @@ def test_ambiguous_input_cannot_collapse_into_one_concrete_batch():
                 "moved",
                 (first, second),
                 ExactAmount(1),
-                selector="SKU-X in BIN-A",
+                selector=selection(
+                    "SEL-X",
+                    "SKU-X",
+                    "BIN-A",
+                    first,
+                    second,
+                ),
             ),),
             outputs=(ProcessOutput(
                 "destination",

--- a/tests/test_process_quantities.py
+++ b/tests/test_process_quantities.py
@@ -13,6 +13,7 @@ from inventorius.process_quantities import (
     FromInput,
     FromSource,
     ObservationEvent,
+    PreservedIdentityOutput,
     ProcessEvent,
     ProcessInput,
     ProcessOutput,
@@ -611,3 +612,49 @@ def test_ambiguous_input_cannot_collapse_into_one_concrete_batch():
                 FromInput("moved"),
             ),),
         )
+
+
+def test_ambiguous_move_preserves_each_possible_batch_allocation():
+    first_source = HoldingKey("BAT-A", "BIN-A", "each")
+    second_source = HoldingKey("BAT-B", "BIN-A", "each")
+    first_destination = HoldingKey("BAT-A", "BIN-B", "each")
+    second_destination = HoldingKey("BAT-B", "BIN-B", "each")
+    timeline = ProcessQuantityTimeline()
+    timeline.record(exact_observation("OBS-A-ten", first_source, 10, 1))
+    timeline.record(exact_observation("OBS-B-ten", second_source, 10, 1))
+    timeline.record(ProcessEvent(
+        "PROC-ambiguous-move",
+        "move",
+        moment(2),
+        moment(2),
+        inputs=(ProcessInput(
+            "moved",
+            (first_source, second_source),
+            ExactAmount(5),
+            selector=selection(
+                "SEL-X",
+                "SKU-X",
+                "BIN-A",
+                first_source,
+                second_source,
+            ),
+        ),),
+        preserved_outputs=(PreservedIdentityOutput(
+            "destination",
+            "moved",
+            "BIN-B",
+        ),),
+    ))
+
+    compiled = timeline.compile()
+
+    assert_bounds(compiled.current_bounds(first_source), 5, 10)
+    assert_bounds(compiled.current_bounds(second_source), 5, 10)
+    assert_bounds(compiled.current_total_bounds(
+        (first_source, second_source),
+    ), 15, 15)
+    assert_bounds(compiled.current_bounds(first_destination), 0, 5)
+    assert_bounds(compiled.current_bounds(second_destination), 0, 5)
+    assert_bounds(compiled.current_total_bounds(
+        (first_destination, second_destination),
+    ), 5, 5)

--- a/tests/test_process_quantities.py
+++ b/tests/test_process_quantities.py
@@ -1,0 +1,390 @@
+"""Executable scenarios for the process-oriented quantity compiler."""
+
+from datetime import datetime, timezone
+from fractions import Fraction
+
+import pytest
+
+from inventorius.ledger import HoldingKey
+from inventorius.process_quantities import (
+    ALL_REMAINING,
+    ExactAmount,
+    FromInput,
+    ObservationEvent,
+    ProcessEvent,
+    ProcessInput,
+    ProcessOutput,
+    ProcessQuantityTimeline,
+    ProcessSink,
+)
+from inventorius.quantity_constraints import (
+    InfeasibleQuantityFacts,
+    ObservationBasis,
+    QuantityDomain,
+    QuantityObservation,
+)
+
+
+DISCRETE = QuantityDomain.DISCRETE
+
+
+def moment(day: int, hour: int = 12) -> datetime:
+    return datetime(2026, 8, day, hour, tzinfo=timezone.utc)
+
+
+def observation(
+    event_id: str,
+    holding: HoldingKey,
+    claim: QuantityObservation,
+    day: int,
+    recorded_day: int | None = None,
+) -> ObservationEvent:
+    assert event_id == claim.observation_id
+    return ObservationEvent(
+        holding,
+        DISCRETE,
+        claim,
+        moment(day),
+        moment(day if recorded_day is None else recorded_day),
+    )
+
+
+def exact_observation(
+    event_id: str,
+    holding: HoldingKey,
+    amount: int,
+    day: int,
+    recorded_day: int | None = None,
+) -> ObservationEvent:
+    return observation(
+        event_id,
+        holding,
+        QuantityObservation.exact(
+            event_id,
+            amount,
+            basis=ObservationBasis.COUNTED,
+        ),
+        day,
+        recorded_day,
+    )
+
+
+def assert_bounds(bounds, minimum, maximum):
+    assert bounds.minimum == (
+        None if minimum is None else Fraction(str(minimum))
+    )
+    assert bounds.maximum == (
+        None if maximum is None else Fraction(str(maximum))
+    )
+
+
+def test_move_consumes_only_the_selected_amount_and_derives_the_remainder():
+    source = HoldingKey("BAT-SCREW", "BIN-A", "each")
+    destination = HoldingKey("BAT-SCREW", "BIN-B", "each")
+    timeline = ProcessQuantityTimeline()
+    timeline.record(exact_observation("OBS-ten", source, 10, 1))
+    timeline.record(ProcessEvent(
+        "PROC-move-three",
+        "move",
+        moment(2),
+        moment(2),
+        inputs=(ProcessInput("moved", (source,), ExactAmount(3)),),
+        outputs=(ProcessOutput(
+            "destination",
+            destination,
+            DISCRETE,
+            FromInput("moved"),
+        ),),
+    ))
+
+    compiled = timeline.compile()
+
+    assert_bounds(compiled.current_bounds(source), 7, 7)
+    assert_bounds(compiled.current_bounds(destination), 3, 3)
+    rendered = "\n".join(compiled.rendered_constraints())
+    assert "PROC-move-three:moved:source" in rendered
+    assert "PROC-move-three:destination:destination" in rendered
+    assert "remainder" not in rendered
+
+
+def test_same_sku_same_bin_preserves_unknown_batch_allocation():
+    first = HoldingKey("BAT-A", "BIN-SHARED", "each")
+    second = HoldingKey("BAT-B", "BIN-SHARED", "each")
+    timeline = ProcessQuantityTimeline()
+    timeline.record(exact_observation("OBS-A-ten", first, 10, 1))
+    timeline.record(exact_observation("OBS-B-ten", second, 10, 1))
+    timeline.record(ProcessEvent(
+        "PROC-take-five",
+        "consume",
+        moment(2),
+        moment(2),
+        inputs=(ProcessInput(
+            "fasteners",
+            (first, second),
+            ExactAmount(5),
+            selector="SKU-FASTENER observed in BIN-SHARED",
+        ),),
+        sinks=(ProcessSink(
+            "project",
+            "consumed by project",
+            "each",
+            DISCRETE,
+            FromInput("fasteners"),
+        ),),
+    ))
+
+    compiled = timeline.compile()
+
+    assert_bounds(compiled.current_bounds(first), 5, 10)
+    assert_bounds(compiled.current_bounds(second), 5, 10)
+    assert_bounds(compiled.current_total_bounds((first, second)), 15, 15)
+    assert_bounds(
+        compiled.allocation_bounds("PROC-take-five", "fasteners", first),
+        0,
+        5,
+    )
+    assert_bounds(
+        compiled.allocation_bounds("PROC-take-five", "fasteners", second),
+        0,
+        5,
+    )
+
+
+def test_audit_constraints_can_assert_lower_upper_or_complete_count():
+    holding = HoldingKey("BAT-BOLTS", "BIN-AUDIT", "each")
+    timeline = ProcessQuantityTimeline()
+    timeline.record(observation(
+        "OBS-saw-ten",
+        holding,
+        QuantityObservation(
+            "OBS-saw-ten",
+            lower=10,
+            basis=ObservationBasis.COUNTED,
+        ),
+        1,
+    ))
+    lower_only = timeline.compile()
+    assert_bounds(lower_only.current_bounds(holding), 10, None)
+
+    timeline.record(observation(
+        "OBS-container-at-most-forty",
+        holding,
+        QuantityObservation(
+            "OBS-container-at-most-forty",
+            upper=40,
+            basis=ObservationBasis.MEASURED,
+        ),
+        2,
+    ))
+    bounded = timeline.compile()
+    assert_bounds(bounded.current_bounds(holding), 10, 40)
+
+    timeline.record(exact_observation("OBS-complete-count", holding, 25, 3))
+    exact = timeline.compile()
+    assert_bounds(exact.current_bounds(holding), 25, 25)
+
+
+def test_whole_batch_reclassification_consumes_identity_not_a_remainder():
+    old = HoldingKey("BAT-WRONG", "BIN-PARTS", "each")
+    new = HoldingKey("BAT-CORRECT", "BIN-PARTS", "each")
+    timeline = ProcessQuantityTimeline()
+    timeline.record(observation(
+        "OBS-old-estimate",
+        old,
+        QuantityObservation(
+            "OBS-old-estimate",
+            lower=8,
+            preferred=10,
+            upper=12,
+            basis=ObservationBasis.ESTIMATED,
+        ),
+        1,
+    ))
+    timeline.record(ProcessEvent(
+        "PROC-reclassify",
+        "reclassify",
+        moment(2),
+        moment(2),
+        inputs=(ProcessInput("old-batch", (old,), ALL_REMAINING),),
+        outputs=(ProcessOutput(
+            "new-batch",
+            new,
+            DISCRETE,
+            FromInput("old-batch"),
+        ),),
+    ))
+
+    compiled = timeline.compile()
+
+    assert_bounds(compiled.current_bounds(old), 0, 0)
+    assert_bounds(compiled.current_bounds(new), 8, 12)
+    assert_bounds(compiled.input_bounds("PROC-reclassify", "old-batch"), 8, 12)
+
+
+def test_assembly_is_a_normal_process_without_adding_incompatible_units():
+    screws = HoldingKey("BAT-SCREWS", "BIN-SCREWS", "each")
+    body = HoldingKey("BAT-BODY", "BIN-BODIES", "each")
+    machine = HoldingKey("BAT-MACHINE", "BENCH", "each")
+    timeline = ProcessQuantityTimeline()
+    timeline.record(exact_observation("OBS-screws", screws, 20, 1))
+    timeline.record(exact_observation("OBS-body", body, 1, 1))
+    timeline.record(ProcessEvent(
+        "PROC-assemble",
+        "assembly",
+        moment(2),
+        moment(2),
+        inputs=(
+            ProcessInput(
+                "fasteners",
+                (screws,),
+                ExactAmount(4),
+                "fasteners",
+                contributes_to=("machine",),
+            ),
+            ProcessInput(
+                "body",
+                (body,),
+                ExactAmount(1),
+                "machine body",
+                contributes_to=("machine",),
+            ),
+        ),
+        outputs=(ProcessOutput(
+            "machine",
+            machine,
+            DISCRETE,
+            ExactAmount(1),
+            "assembled machine",
+        ),),
+    ))
+
+    compiled = timeline.compile()
+
+    assert_bounds(compiled.current_bounds(screws), 16, 16)
+    assert_bounds(compiled.current_bounds(body), 0, 0)
+    assert_bounds(compiled.current_bounds(machine), 1, 1)
+
+
+def test_late_process_replays_by_occurrence_time_and_can_break_future_history():
+    source = HoldingKey("BAT-LATE", "BIN-A", "each")
+    moved = HoldingKey("BAT-LATE", "BIN-B", "each")
+    timeline = ProcessQuantityTimeline()
+    timeline.record(exact_observation("OBS-opening-ten", source, 10, 1))
+    timeline.record(ProcessEvent(
+        "PROC-move-six",
+        "move",
+        moment(3),
+        moment(3),
+        inputs=(ProcessInput("moved", (source,), ExactAmount(6)),),
+        outputs=(ProcessOutput(
+            "destination",
+            moved,
+            DISCRETE,
+            FromInput("moved"),
+        ),),
+    ))
+    timeline.record(exact_observation("OBS-four-remain", source, 4, 4))
+
+    before_late_record = timeline.compile(known_at=moment(4, 13))
+    assert before_late_record.is_feasible()
+    assert_bounds(before_late_record.current_bounds(source), 4, 4)
+
+    timeline.record(ProcessEvent(
+        "PROC-late-five",
+        "consume",
+        moment(2),
+        moment(5),
+        inputs=(ProcessInput("consumed", (source,), ExactAmount(5)),),
+        sinks=(ProcessSink(
+            "unknown-use",
+            "late-recorded consumption",
+            "each",
+            DISCRETE,
+            FromInput("consumed"),
+        ),),
+        note="Recorded three days after it occurred",
+    ))
+
+    after_late_record = timeline.compile(known_at=moment(5, 13))
+    assert after_late_record.event_order == (
+        "OBS-opening-ten",
+        "PROC-late-five",
+        "PROC-move-six",
+        "OBS-four-remain",
+    )
+    assert not after_late_record.is_feasible()
+    assert "PROC-late-five:consumed:source" in after_late_record.conflict()
+    with pytest.raises(InfeasibleQuantityFacts):
+        after_late_record.current_bounds(source)
+
+
+def test_process_validation_stops_undefined_same_holding_semantics():
+    holding = HoldingKey("BAT-X", "BIN-X", "each")
+    with pytest.raises(ValueError, match="same-holding"):
+        ProcessEvent(
+            "PROC-undefined",
+            "undefined",
+            moment(1),
+            moment(1),
+            inputs=(ProcessInput("input", (holding,), ExactAmount(1)),),
+            outputs=(ProcessOutput(
+                "output",
+                holding,
+                DISCRETE,
+                FromInput("input"),
+            ),),
+        )
+
+
+def test_process_input_cannot_be_a_meaningless_withdrawal():
+    holding = HoldingKey("BAT-X", "BIN-X", "each")
+    with pytest.raises(ValueError, match="output, sink, or structural"):
+        ProcessEvent(
+            "PROC-bare-withdrawal",
+            "use",
+            moment(1),
+            moment(1),
+            inputs=(ProcessInput("input", (holding,), ExactAmount(1)),),
+        )
+
+
+def test_output_only_process_waits_for_explicit_external_source_semantics():
+    holding = HoldingKey("BAT-X", "BIN-X", "each")
+    with pytest.raises(ValueError, match="external-source"):
+        ProcessEvent(
+            "PROC-anonymous-creation",
+            "receive",
+            moment(1),
+            moment(1),
+            outputs=(ProcessOutput(
+                "received",
+                holding,
+                DISCRETE,
+                ExactAmount(1),
+            ),),
+        )
+
+
+def test_ambiguous_input_cannot_collapse_into_one_concrete_batch():
+    first = HoldingKey("BAT-A", "BIN-A", "each")
+    second = HoldingKey("BAT-B", "BIN-A", "each")
+    output = HoldingKey("BAT-A", "BIN-B", "each")
+    with pytest.raises(ValueError, match="ambiguous input"):
+        ProcessEvent(
+            "PROC-ambiguous-move",
+            "move",
+            moment(1),
+            moment(1),
+            inputs=(ProcessInput(
+                "moved",
+                (first, second),
+                ExactAmount(1),
+                selector="SKU-X in BIN-A",
+            ),),
+            outputs=(ProcessOutput(
+                "destination",
+                output,
+                DISCRETE,
+                FromInput("moved"),
+            ),),
+        )


### PR DESCRIPTION
## Summary

This is a persistence-free executable checkpoint for the systematic inventory model. It:

- compiles observations and process participation into the existing exact quantity solver;
- derives source remainders instead of recording them as outputs;
- models named, bounded external sources for receipts;
- expands whole-Batch identity replacement across every holding visible during replay;
- separates occurrence time, recording time, and explicit equal-time physical order;
- preserves an observed SKU/location selector and its at-recording candidate snapshot;
- carries ambiguous per-Batch allocations through identity-preserving moves; and
- provides readable traces for receipt, move, audit, assembly, reclassification, late discovery, and contradiction.

## Review focus

Please review the domain semantics rather than treating this as a persistence implementation:

- Does the external-boundary model avoid anonymous inventory creation?
- Does knowledge-sensitive candidate resolution preserve what was known without freezing an arbitrary Batch?
- Do preserved-identity moves retain the required correlations?
- Is replay-time Batch-wide replacement the correct meaning for reclassification?
- Is `effective_order` an acceptable narrow first mechanism for overlapping equal-time events?

Identity-merging ambiguous transformations and split external receipts deliberately remain fail-closed.

## Verification

- Full API suite: 387 passed
- Focused quantity/process/provenance suite: 44 passed
- Readable trace script executed successfully

## Not included

No MongoDB documents, HTTP operations, authorization surface, frontend changes, migration, deployment, correction workflow, or financial projection are introduced here.